### PR TITLE
feat: add Braze campaigns trigger send

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 
 ### Send messages
 
-- [ ] /campaigns/trigger/send
+- [x] /campaigns/trigger/send
 - [ ] /canvas/trigger/send
 - [x] /messages/send
 - [ ] /sends/id/create

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -1,13 +1,16 @@
+import type { CampaignsTriggerSendObject, MessagesSendObject } from '.'
 import { Braze } from '.'
-import * as messages from './messages'
+import { request } from './common/request'
 
-jest.mock('./messages')
-const mockedMessages = jest.mocked(messages)
+jest.mock('./common/request/request')
+const mockedRequest = jest.mocked(request)
 
 const apiUrl = 'https://rest.iad-01.braze.com'
 const apiKey = 'apiKey'
-const body = {}
-const data = {}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
 
 describe('Braze', () => {
   it('exports class', () => {
@@ -31,15 +34,27 @@ describe('Braze', () => {
   })
 })
 
-describe('messages', () => {
-  beforeEach(() => {
-    mockedMessages.send.mockClear().mockResolvedValueOnce(data)
-  })
+const braze = new Braze(apiUrl, apiKey)
+const body = {}
+const options = {
+  headers: {
+    Authorization: `Bearer ${apiKey}`,
+    'Content-Type': 'application/json',
+  },
+  method: expect.stringMatching(/^GET|POST$/),
+}
+const response = {}
 
-  it('sends messages immediately via API', async () => {
-    const braze = new Braze(apiUrl, apiKey)
-    expect(await braze.messages.send(body as messages.MessagesSendObject)).toBe(data)
-    expect(mockedMessages.send).toBeCalledWith(apiUrl, apiKey, body)
-    expect(mockedMessages.send).toBeCalledTimes(1)
-  })
+it('calls messages.send()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.messages.send(body as MessagesSendObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/messages/send`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls campaigns.trigger.send()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.campaigns.trigger.send(body as CampaignsTriggerSendObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/send`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
 })

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -1,3 +1,4 @@
+import * as campaigns from './campaigns'
 import * as messages from './messages'
 
 export class Braze {
@@ -26,6 +27,13 @@ export class Braze {
 
     this.apiUrl = apiUrl
     this.apiKey = apiKey
+  }
+
+  campaigns = {
+    trigger: {
+      send: (body: campaigns.trigger.CampaignsTriggerSendObject) =>
+        campaigns.trigger.send(this.apiUrl, this.apiKey, body),
+    },
   }
 
   messages = {

--- a/src/campaigns/index.ts
+++ b/src/campaigns/index.ts
@@ -1,0 +1,1 @@
+export * as trigger from './trigger'

--- a/src/campaigns/trigger/index.ts
+++ b/src/campaigns/trigger/index.ts
@@ -1,0 +1,2 @@
+export * from './send'
+export * from './types'

--- a/src/campaigns/trigger/send.test.ts
+++ b/src/campaigns/trigger/send.test.ts
@@ -1,0 +1,43 @@
+import { post } from '../../common/request'
+import { send } from '.'
+import type { CampaignsTriggerSendObject } from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/campaigns/trigger/send', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CampaignsTriggerSendObject = {
+    campaign_id: 'abcdef12-3456-7890-abcd-ef1234567890',
+    recipients: [
+      {
+        external_user_id: '1234567890',
+        trigger_properties: {
+          example_string_property: 'YOUR_EXAMPLE_STRING',
+          example_integer_property: 1234567890,
+          nested: {
+            foo: 'bar',
+          },
+        },
+      },
+    ],
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await send(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/campaigns/trigger/send`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/campaigns/trigger/send.ts
+++ b/src/campaigns/trigger/send.ts
@@ -1,0 +1,24 @@
+import { post } from '../../common/request'
+import type { CampaignsTriggerSendObject } from './types'
+
+/**
+ * Sending campaign messages via API-triggered delivery.
+ *
+ * The send endpoint allows you to send immediate, ad-hoc messages to designated users.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function send(apiUrl: string, apiKey: string, body: CampaignsTriggerSendObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+  return post(`${apiUrl}/campaigns/trigger/send`, body, options)
+}

--- a/src/campaigns/trigger/types.ts
+++ b/src/campaigns/trigger/types.ts
@@ -1,0 +1,34 @@
+import type { ConnectedAudienceObject } from '../../common/types'
+
+/**
+ * Request body for sending campaign messages via API-triggered delivery.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/#request-body}
+ */
+export interface CampaignsTriggerSendObject {
+  campaign_id: string
+  send_id?: string
+  trigger_properties?: TriggerProperties
+  broadcast?: boolean
+  audience?: ConnectedAudienceObject
+  recipients?: (RecipientWithExternalUserId | RecipientWithUserAlias)[]
+}
+
+type TriggerProperties = object
+
+interface Recipient {
+  trigger_properties?: TriggerProperties
+  send_to_existing_only?: boolean
+  attributes?: object
+}
+
+interface RecipientWithExternalUserId extends Recipient {
+  external_user_id: string
+}
+
+interface RecipientWithUserAlias extends Recipient {
+  user_alias: {
+    alias_name: string
+    alias_label: string
+  }
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,0 +1,50 @@
+/**
+ * A Connected Audience Object is a selector that identifies the audience to send the message to. It is composed of either a single Connected Audience Filter or several Connected Audience Filters in a logical expression using either AND or OR operators.
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/connected_audience/}
+ */
+export interface ConnectedAudienceObject {
+  AND?: (ConnectedAudienceFilter | ConnectedAudienceObject)[]
+  OR?: (ConnectedAudienceFilter | ConnectedAudienceObject)[]
+}
+
+interface ConnectedAudienceFilter {
+  custom_attribute?: {
+    custom_attribute_name: string
+    comparison: Comparison
+    value: string | number | boolean
+  }
+  push_subscription_status?: {
+    comparison: 'is' | 'is_not'
+    value: 'opted_in' | 'subscribed' | 'unsubscribed'
+  }
+  email_subscription_status?: {
+    comparison: 'is' | 'is_not'
+    value: 'opted_in' | 'subscribed' | 'unsubscribed'
+  }
+  last_used_app?: {
+    comparison: 'after' | 'before'
+    value: string
+  }
+}
+
+type Comparison =
+  | 'after'
+  | 'before'
+  | 'does_not_equal'
+  | 'does_not_exist'
+  | 'does_not_include_value'
+  | 'does_not_match_regex'
+  | 'equals'
+  | 'exists'
+  | 'greater_than'
+  | 'greater_than_or_equal_to'
+  | 'greater_than_x_days_ago'
+  | 'greater_than_x_days_in_the_future'
+  | 'includes_value'
+  | 'less_than'
+  | 'less_than_or_equal_to'
+  | 'less_than_x_days_ago'
+  | 'less_than_x_days_in_the_future'
+  | 'matches_regex'
+  | 'not_equal'

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,4 @@
 export * from './Braze'
+export * from './campaigns/trigger/types'
+export * from './common/types'
 export * from './messages/types'

--- a/src/messages/send.test.ts
+++ b/src/messages/send.test.ts
@@ -5,6 +5,10 @@ import type { MessagesSendObject } from './types'
 jest.mock('../common/request')
 const mockedPost = jest.mocked(post)
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 describe('/messages/send', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
@@ -20,11 +24,8 @@ describe('/messages/send', () => {
   }
   const data = {}
 
-  beforeEach(() => {
-    mockedPost.mockClear().mockResolvedValueOnce(data)
-  })
-
   it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
     expect(await send(apiUrl, apiKey, body)).toBe(data)
     expect(mockedPost).toBeCalledWith(`${apiUrl}/messages/send`, body, {
       headers: {

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -1,3 +1,5 @@
+import type { ConnectedAudienceObject } from '../common/types'
+
 /**
  * Request body for sending messages immediately via API only.
  *
@@ -18,57 +20,6 @@ export interface MessagesSendObject {
   recipient_subscription_state?: string
   messages?: MessagesObject
 }
-
-/**
- * A Connected Audience Object is a selector that identifies the audience to send the message to. It is composed of either a single Connected Audience Filter or several Connected Audience Filters in a logical expression using either AND or OR operators.
- *
- * {@link https://www.braze.com/docs/api/objects_filters/connected_audience/}
- */
-export interface ConnectedAudienceObject {
-  AND?: (ConnectedAudienceFilter | ConnectedAudienceObject)[]
-  OR?: (ConnectedAudienceFilter | ConnectedAudienceObject)[]
-}
-
-interface ConnectedAudienceFilter {
-  custom_attribute?: {
-    custom_attribute_name: string
-    comparison: Comparison
-    value: string | number | boolean
-  }
-  push_subscription_status?: {
-    comparison: 'is' | 'is_not'
-    value: 'opted_in' | 'subscribed' | 'unsubscribed'
-  }
-  email_subscription_status?: {
-    comparison: 'is' | 'is_not'
-    value: 'opted_in' | 'subscribed' | 'unsubscribed'
-  }
-  last_used_app?: {
-    comparison: 'after' | 'before'
-    value: string
-  }
-}
-
-type Comparison =
-  | 'after'
-  | 'before'
-  | 'does_not_equal'
-  | 'does_not_exist'
-  | 'does_not_include_value'
-  | 'does_not_match_regex'
-  | 'equals'
-  | 'exists'
-  | 'greater_than'
-  | 'greater_than_or_equal_to'
-  | 'greater_than_x_days_ago'
-  | 'greater_than_x_days_in_the_future'
-  | 'includes_value'
-  | 'less_than'
-  | 'less_than_or_equal_to'
-  | 'less_than_x_days_ago'
-  | 'less_than_x_days_in_the_future'
-  | 'matches_regex'
-  | 'not_equal'
 
 /**
  * Messaging objects.
@@ -111,10 +62,8 @@ interface EmailObject {
 
 interface EmailObjectWithBody extends EmailObject {
   body: string
-  email_template_id?: string
 }
 
 interface EmailObjectWithEmailTemplateId extends EmailObject {
-  body?: string
   email_template_id: string
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add Braze campaigns trigger send

https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_campaigns/

## What is the current behavior?

No support for POST /campaigns/trigger/send

## What is the new behavior?

Added method `braze.campaigns.trigger.send()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation