### PR TITLE
feat: add users identify

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [ ] /users/export/segment
 - [ ] /users/external_ids/rename
 - [ ] /users/external_ids/remove
-- [ ] /users/identify
+- [x] /users/identify
 - [x] /users/track
 
 ### Send messages

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -2,6 +2,7 @@ import type {
   CampaignsTriggerSendObject,
   MessagesSendObject,
   TransactionalV1CampaignsSendObject,
+  UsersIdentifyObject,
   UsersTrackObject,
 } from '.'
 import { Braze } from '.'
@@ -78,6 +79,13 @@ it('calls transactional.v1.campaigns.send()', async () => {
     body,
     options,
   )
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls users.identify()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.users.identify(body as UsersIdentifyObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/identify`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -54,6 +54,8 @@ export class Braze {
   }
 
   users = {
+    identify: (body: users.UsersIdentifyObject) => users.identify(this.apiUrl, this.apiKey, body),
+
     track: (body: users.UsersTrackObject, bulk?: boolean) =>
       users.track(this.apiUrl, this.apiKey, body, bulk),
   }

--- a/src/users/identify.test.ts
+++ b/src/users/identify.test.ts
@@ -1,0 +1,40 @@
+import { post } from '../common/request'
+import { identify } from '.'
+import type { UsersIdentifyObject } from './types'
+
+jest.mock('../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/users/identify', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: UsersIdentifyObject = {
+    aliases_to_identify: [
+      {
+        external_id: 'external_identifier',
+        user_alias: {
+          alias_name: 'example_alias',
+          alias_label: 'example_label',
+        },
+      },
+    ],
+  }
+
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await identify(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/users/identify`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/users/identify.ts
+++ b/src/users/identify.ts
@@ -1,0 +1,25 @@
+import { post } from '../common/request'
+import type { UsersIdentifyObject } from './types'
+
+/**
+ * Identify users.
+ *
+ * Use this endpoint to identify an unidentified (alias-only) user.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function identify(apiUrl: string, apiKey: string, body: UsersIdentifyObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/users/identify`, body, options)
+}

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,2 +1,3 @@
+export * from './identify'
 export * from './track'
 export * from './types'

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -12,6 +12,18 @@ export interface UsersTrackObject {
 }
 
 /**
+ * Request body for user track.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-body}
+ */
+export interface UsersIdentifyObject {
+  aliases_to_identify: {
+    external_id: string
+    user_alias: UserAlias
+  }[]
+}
+
+/**
  * User attributes object specification.
  *
  * {@link https://www.braze.com/docs/api/objects_filters/user_attributes_object}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add users identify

https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/

## What is the current behavior?

No users identify

## What is the new behavior?

Users identify: `braze.users.identify()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation