### PR TITLE
feat: add users delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 ### User data
 
 - [x] /users/alias/new
-- [ ] /users/delete
+- [x] /users/delete
 - [ ] /users/export/global_control_group
 - [ ] /users/export/ids
 - [ ] /users/export/segment

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -3,6 +3,7 @@ import type {
   MessagesSendObject,
   TransactionalV1CampaignsSendObject,
   UsersAliasObject,
+  UsersDeleteObject,
   UsersIdentifyObject,
   UsersTrackObject,
 } from '.'
@@ -87,6 +88,13 @@ it('calls users.alias.new()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.users.alias.new(body as UsersAliasObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/alias/new`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls users.delete()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.users.delete(body as UsersDeleteObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/delete`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -58,6 +58,8 @@ export class Braze {
       new: (body: users.alias.UsersAliasObject) => users.alias._new(this.apiUrl, this.apiKey, body),
     },
 
+    delete: (body: users.UsersDeleteObject) => users._delete(this.apiUrl, this.apiKey, body),
+
     identify: (body: users.UsersIdentifyObject) => users.identify(this.apiUrl, this.apiKey, body),
 
     track: (body: users.UsersTrackObject, bulk?: boolean) =>

--- a/src/users/delete.test.ts
+++ b/src/users/delete.test.ts
@@ -1,0 +1,43 @@
+import { post } from '../common/request'
+import { _delete } from '.'
+import type { UsersDeleteObject } from './types'
+
+jest.mock('../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/users/delete', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: UsersDeleteObject = {
+    external_ids: ['external_identifier1', 'external_identifier2'],
+    braze_ids: ['braze_identifier1', 'braze_identifier2'],
+    user_aliases: [
+      {
+        alias_name: 'user_alias1',
+        alias_label: 'alias_label1',
+      },
+      {
+        alias_name: 'user_alias2',
+        alias_label: 'alias_label2',
+      },
+    ],
+  }
+
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await _delete(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/users/delete`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/users/delete.ts
+++ b/src/users/delete.ts
@@ -1,0 +1,27 @@
+import { post } from '../common/request'
+import type { UsersDeleteObject } from './types'
+
+/**
+ * User delete endpoint.
+ *
+ * This endpoint allows you to delete any user profile by specifying a known user identifier.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_delete/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function _delete(apiUrl: string, apiKey: string, body: UsersDeleteObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/users/delete`, body, options) as Promise<{
+    deleted: number
+  }>
+}

--- a/src/users/index.ts
+++ b/src/users/index.ts
@@ -1,4 +1,5 @@
 export * as alias from './alias'
+export * from './delete'
 export * from './identify'
 export * from './track'
 export * from './types'

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -12,7 +12,7 @@ export interface UsersTrackObject {
 }
 
 /**
- * Request body for user track.
+ * Request body for user identify.
  *
  * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/#request-body}
  */
@@ -21,6 +21,17 @@ export interface UsersIdentifyObject {
     external_id: string
     user_alias: UserAlias
   }[]
+}
+
+/**
+ * Request body for user delete.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_delete/#request-body}
+ */
+export interface UsersDeleteObject {
+  external_ids?: string[]
+  user_aliases?: UserAlias[]
+  braze_ids?: string[]
 }
 
 /**


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add users delete

https://www.braze.com/docs/api/endpoints/user_data/post_user_delete/

## What is the current behavior?

No way to delete a user profile

## What is the new behavior?

Add method to delete user profile: `braze.users.delete()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation