### PR TITLE
feat: add canvas trigger send

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 ### Send messages
 
 - [x] /campaigns/trigger/send
-- [ ] /canvas/trigger/send
+- [x] /canvas/trigger/send
 - [x] /messages/send
 - [ ] /sends/id/create
 - [x] /transactional/v1/campaigns/{{CAMPAIGN_ID}}/send

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -1,5 +1,6 @@
 import type {
   CampaignsTriggerSendObject,
+  CanvasTriggerSendObject,
   MessagesSendObject,
   TransactionalV1CampaignsSendObject,
   UsersAliasObject,
@@ -57,6 +58,13 @@ it('calls campaigns.trigger.send()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.campaigns.trigger.send(body as CampaignsTriggerSendObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/send`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls canvas.trigger.send()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.canvas.trigger.send(body as CanvasTriggerSendObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/canvas/trigger/send`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -1,4 +1,5 @@
 import * as campaigns from './campaigns'
+import * as canvas from './canvas'
 import * as messages from './messages'
 import * as transactional from './transactional'
 import * as users from './users'
@@ -35,6 +36,13 @@ export class Braze {
     trigger: {
       send: (body: campaigns.trigger.CampaignsTriggerSendObject) =>
         campaigns.trigger.send(this.apiUrl, this.apiKey, body),
+    },
+  }
+
+  canvas = {
+    trigger: {
+      send: (body: canvas.trigger.CanvasTriggerSendObject) =>
+        canvas.trigger.send(this.apiUrl, this.apiKey, body),
     },
   }
 

--- a/src/campaigns/trigger/types.ts
+++ b/src/campaigns/trigger/types.ts
@@ -25,10 +25,10 @@ interface Recipient {
   attributes?: Attributes
 }
 
-export interface RecipientWithExternalUserId extends Recipient {
+interface RecipientWithExternalUserId extends Recipient {
   external_user_id: string
 }
 
-export interface RecipientWithUserAlias extends Recipient {
+interface RecipientWithUserAlias extends Recipient {
   user_alias: UserAlias
 }

--- a/src/canvas/index.ts
+++ b/src/canvas/index.ts
@@ -1,0 +1,1 @@
+export * as trigger from './trigger'

--- a/src/canvas/trigger/index.ts
+++ b/src/canvas/trigger/index.ts
@@ -1,0 +1,2 @@
+export * from './send'
+export * from './types'

--- a/src/canvas/trigger/send.test.ts
+++ b/src/canvas/trigger/send.test.ts
@@ -1,0 +1,94 @@
+import { post } from '../../common/request'
+import { send } from '.'
+import type { CanvasTriggerSendObject } from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/canvas/trigger/send', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CanvasTriggerSendObject = {
+    canvas_id: 'canvas_identifier',
+    canvas_entry_properties: { product_name: 'shoes', product_price: 79.99 },
+    broadcast: false,
+    audience: {
+      AND: [
+        {
+          custom_attribute: {
+            custom_attribute_name: 'eye_color',
+            comparison: 'equals',
+            value: 'blue',
+          },
+        },
+        {
+          custom_attribute: {
+            custom_attribute_name: 'favorite_foods',
+            comparison: 'includes_value',
+            value: 'pizza',
+          },
+        },
+        {
+          OR: [
+            {
+              custom_attribute: {
+                custom_attribute_name: 'last_purchase_time',
+                comparison: 'less_than_x_days_ago',
+                value: 2,
+              },
+            },
+            {
+              push_subscription_status: {
+                comparison: 'is',
+                value: 'opted_in',
+              },
+            },
+          ],
+        },
+        {
+          email_subscription_status: {
+            comparison: 'is_not',
+            value: 'subscribed',
+          },
+        },
+        {
+          last_used_app: {
+            comparison: 'after',
+            value: '2019-07-22T13:17:55+0000',
+          },
+        },
+      ],
+    },
+    recipients: [
+      {
+        user_alias: {
+          alias_name: 'example_name',
+          alias_label: 'example_label',
+        },
+        external_user_id: 'user_identifier',
+        canvas_entry_properties: {},
+        send_to_existing_only: true,
+        attributes: {
+          first_name: 'Alex',
+        },
+      },
+    ],
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await send(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/canvas/trigger/send`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/canvas/trigger/send.ts
+++ b/src/canvas/trigger/send.ts
@@ -1,0 +1,28 @@
+import { post } from '../../common/request'
+import type { CanvasTriggerSendObject } from './types'
+
+/**
+ * Sending Canvas messages via API-triggered delivery.
+ *
+ * This endpoint allows you to send Canvas messages via API-Triggered delivery, allowing you to decide what action should trigger the message to be sent.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_canvases/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function send(apiUrl: string, apiKey: string, body: CanvasTriggerSendObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/canvas/trigger/send`, body, options) as Promise<{
+    dispatch_id: string
+    message: string
+  }>
+}

--- a/src/canvas/trigger/types.ts
+++ b/src/canvas/trigger/types.ts
@@ -1,0 +1,30 @@
+import type { Attributes, ConnectedAudienceObject, UserAlias } from '../../common/types'
+
+/**
+ * Request body for sending Canvas messages via API-triggered delivery.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_canvases/#request-body}
+ */
+export interface CanvasTriggerSendObject {
+  canvas_id: string
+  canvas_entry_properties?: CanvasEntryProperties
+  broadcast?: boolean
+  audience?: ConnectedAudienceObject
+  recipients?: (RecipientWithExternalUserId | RecipientWithUserAlias)[]
+}
+
+type CanvasEntryProperties = object
+
+interface Recipient {
+  canvas_entry_properties?: CanvasEntryProperties
+  send_to_existing_only?: boolean
+  attributes?: Attributes
+}
+
+interface RecipientWithExternalUserId extends Recipient {
+  external_user_id: string
+}
+
+interface RecipientWithUserAlias extends Recipient {
+  user_alias: UserAlias
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Braze'
 export * from './campaigns/trigger/types'
+export * from './canvas/trigger/types'
 export * from './common/types'
 export * from './messages/types'
 export * from './transactional/v1/campaigns/types'


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add canvas trigger send

https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_triggered_canvases/

## What is the current behavior?

No ability to send Canvas messages via API-triggered delivery

## What is the new behavior?

Ability to send Canvas messages via API-triggered delivery with `braze.canvas.trigger.send()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation