### PR TITLE
feat: add users external_ids remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [ ] /users/export/ids
 - [ ] /users/export/segment
 - [x] /users/external_ids/rename
-- [ ] /users/external_ids/remove
+- [x] /users/external_ids/remove
 - [x] /users/identify
 - [x] /users/track
 

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -6,6 +6,7 @@ import type {
   TransactionalV1CampaignsSendObject,
   UsersAliasObject,
   UsersDeleteObject,
+  UsersExternalIdsRemoveObject,
   UsersExternalIdsRenameObject,
   UsersIdentifyObject,
   UsersTrackObject,
@@ -112,6 +113,13 @@ it('calls users.delete()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.users.delete(body as UsersDeleteObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/delete`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls users.external_ids.remove()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.users.external_ids.remove(body as UsersExternalIdsRemoveObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/external_ids/remove`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -77,6 +77,9 @@ export class Braze {
     delete: (body: users.UsersDeleteObject) => users._delete(this.apiUrl, this.apiKey, body),
 
     external_ids: {
+      remove: (body: users.external_ids.UsersExternalIdsRemoveObject) =>
+        users.external_ids.remove(this.apiUrl, this.apiKey, body),
+
       rename: (body: users.external_ids.UsersExternalIdsRenameObject) =>
         users.external_ids.rename(this.apiUrl, this.apiKey, body),
     },

--- a/src/users/external_ids/index.ts
+++ b/src/users/external_ids/index.ts
@@ -1,2 +1,3 @@
+export * from './remove'
 export * from './rename'
 export * from './types'

--- a/src/users/external_ids/remove.test.ts
+++ b/src/users/external_ids/remove.test.ts
@@ -1,0 +1,31 @@
+import { post } from '../../common/request'
+import { remove } from '.'
+import type { UsersExternalIdsRemoveObject } from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/users/external_ids/remove', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: UsersExternalIdsRemoveObject = {
+    external_ids: ['existing_deprecated_external_id_string'],
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await remove(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/users/external_ids/remove`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/users/external_ids/remove.ts
+++ b/src/users/external_ids/remove.ts
@@ -1,0 +1,31 @@
+import { post } from '../../common/request'
+import type { UsersExternalIdsRemoveObject } from './types'
+
+/**
+ * External ID remove.
+ *
+ * For security purposes, this feature is disabled by default. To enable this feature, reach out to your Success Manager.
+ *
+ * Use this endpoint to remove your users’ old deprecated external IDs. This endpoint completely removes the deprecated ID and cannot be undone.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/external_id_migration/post_external_ids_remove/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function remove(apiUrl: string, apiKey: string, body: UsersExternalIdsRemoveObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/users/external_ids/remove`, body, options) as Promise<{
+    message: string
+    removed_ids: string[]
+    removal_errors: string[]
+  }>
+}

--- a/src/users/external_ids/types.ts
+++ b/src/users/external_ids/types.ts
@@ -1,4 +1,13 @@
 /**
+ * Request body for external ID remove.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/external_id_migration/post_external_ids_remove/#request-body}
+ */
+export interface UsersExternalIdsRemoveObject {
+  external_ids: string[]
+}
+
+/**
  * Request body for external ID rename.
  *
  * {@link https://www.braze.com/docs/api/endpoints/user_data/external_id_migration/post_external_ids_rename/#request-body}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add users external_ids remove

https://www.braze.com/docs/api/endpoints/user_data/external_id_migration/post_external_ids_remove/

## What is the current behavior?

No way to remove users’ old deprecated external IDs

## What is the new behavior?

Add method to remove users' external IDs: `braze.users.external_ids.remove()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation