### PR TITLE
feat: add users export segment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /users/delete
 - [ ] /users/export/global_control_group
 - [x] /users/export/ids
-- [ ] /users/export/segment
+- [x] /users/export/segment
 - [x] /users/external_ids/rename
 - [x] /users/external_ids/remove
 - [x] /users/identify

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -6,7 +6,8 @@ import type {
   TransactionalV1CampaignsSendObject,
   UsersAliasObject,
   UsersDeleteObject,
-  UsersExportsIdsObject,
+  UsersExportIdsObject,
+  UsersExportSegmentObject,
   UsersExternalIdsRemoveObject,
   UsersExternalIdsRenameObject,
   UsersIdentifyObject,
@@ -119,8 +120,15 @@ it('calls users.delete()', async () => {
 
 it('calls users.export.ids()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
-  expect(await braze.users.export.ids(body as UsersExportsIdsObject)).toBe(response)
+  expect(await braze.users.export.ids(body as UsersExportIdsObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/export/ids`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls users.export.segment()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.users.export.segment(body as UsersExportSegmentObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/export/segment`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -77,8 +77,11 @@ export class Braze {
     delete: (body: users.UsersDeleteObject) => users._delete(this.apiUrl, this.apiKey, body),
 
     export: {
-      ids: (body: users.export.UsersExportsIdsObject) =>
+      ids: (body: users.export.UsersExportIdsObject) =>
         users.export.ids(this.apiUrl, this.apiKey, body),
+
+      segment: (body: users.export.UsersExportSegmentObject) =>
+        users.export.segment(this.apiUrl, this.apiKey, body),
     },
 
     external_ids: {

--- a/src/users/export/ids.test.ts
+++ b/src/users/export/ids.test.ts
@@ -1,6 +1,6 @@
 import { post } from '../../common/request'
 import { ids } from '.'
-import type { UsersExportsIdsObject, UsersExportsIdsResponse } from './types'
+import type { UsersExportIdsObject, UsersExportIdsResponse } from './types'
 
 jest.mock('../../common/request')
 const mockedPost = jest.mocked(post)
@@ -13,7 +13,7 @@ describe('/users/export/ids', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
 
-  const body: UsersExportsIdsObject = {
+  const body: UsersExportIdsObject = {
     external_ids: ['user_identifier1', 'user_identifier2'],
     user_aliases: [
       {
@@ -28,7 +28,7 @@ describe('/users/export/ids', () => {
     fields_to_export: ['first_name', 'email', 'purchases'],
   }
 
-  const data: UsersExportsIdsResponse = {
+  const data: UsersExportIdsResponse = {
     message: 'success',
     users: [
       {

--- a/src/users/export/ids.ts
+++ b/src/users/export/ids.ts
@@ -1,5 +1,5 @@
 import { post } from '../../common/request'
-import type { UsersExportsIdsObject, UsersExportsIdsResponse } from './types'
+import type { UsersExportIdsObject, UsersExportIdsResponse } from './types'
 
 /**
  * Users by identifier endpoint.
@@ -13,7 +13,7 @@ import type { UsersExportsIdsObject, UsersExportsIdsResponse } from './types'
  * @param body - Request parameters.
  * @returns - Braze response.
  */
-export function ids(apiUrl: string, apiKey: string, body: UsersExportsIdsObject) {
+export function ids(apiUrl: string, apiKey: string, body: UsersExportIdsObject) {
   const options = {
     headers: {
       'Content-Type': 'application/json',
@@ -21,5 +21,5 @@ export function ids(apiUrl: string, apiKey: string, body: UsersExportsIdsObject)
     },
   }
 
-  return post(`${apiUrl}/users/export/ids`, body, options) as Promise<UsersExportsIdsResponse>
+  return post(`${apiUrl}/users/export/ids`, body, options) as Promise<UsersExportIdsResponse>
 }

--- a/src/users/export/index.ts
+++ b/src/users/export/index.ts
@@ -1,2 +1,3 @@
 export * from './ids'
+export * from './segment'
 export * from './types'

--- a/src/users/export/segment.test.ts
+++ b/src/users/export/segment.test.ts
@@ -1,0 +1,40 @@
+import { post } from '../../common/request'
+import { segment } from '.'
+import type { UsersExportSegmentObject, UsersExportSegmentResponse } from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/users/export/segment', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const body: UsersExportSegmentObject = {
+    segment_id: 'segment_identifier',
+    callback_endpoint: 'example_endpoint',
+    fields_to_export: ['first_name', 'email', 'purchases'],
+    output_format: 'zip',
+  }
+
+  const data: UsersExportSegmentResponse = {
+    message: 'success',
+    object_prefix: 'bb8e2a91-c4aa-478b-b3f2-a4ee91731ad1-1464728599',
+    url: 'https://example.com/',
+  }
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await segment(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/users/export/segment`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/users/export/segment.ts
+++ b/src/users/export/segment.ts
@@ -1,0 +1,29 @@
+import { post } from '../../common/request'
+import type { UsersExportSegmentObject, UsersExportSegmentResponse } from './types'
+
+/**
+ * Users by segment endpoint.
+ *
+ * This endpoint allows you to export all the users within a segment.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function segment(apiUrl: string, apiKey: string, body: UsersExportSegmentObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(
+    `${apiUrl}/users/export/segment`,
+    body,
+    options,
+  ) as Promise<UsersExportSegmentResponse>
+}

--- a/src/users/export/types.ts
+++ b/src/users/export/types.ts
@@ -5,7 +5,7 @@ import type { UserAlias } from '../../common/types'
  *
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#request-body}
  */
-export interface UsersExportsIdsObject {
+export interface UsersExportIdsObject {
   external_ids?: string[]
   user_aliases?: UserAlias[]
   device_id?: string
@@ -20,10 +20,33 @@ export interface UsersExportsIdsObject {
  *
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#response}
  */
-export interface UsersExportsIdsResponse {
+export interface UsersExportIdsResponse {
   message: string
   users: Partial<UserExportObject>[]
   invalid_user_ids?: string[]
+}
+
+/**
+ * Request body for users by segment endpoint.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/#request-body}
+ */
+export interface UsersExportSegmentObject {
+  segment_id: string
+  callback_endpoint?: string
+  fields_to_export: FieldsToExport[]
+  output_format?: 'zip' | 'gzip'
+}
+
+/**
+ * Response body for users by segment endpoint.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/#response}
+ */
+export interface UsersExportSegmentResponse {
+  message: string
+  object_prefix: string
+  url?: string
 }
 
 interface UserExportObject {
@@ -42,7 +65,7 @@ interface UserExportObject {
   language: string
   time_zone: string
   last_coordinates: [number, number]
-  gender: 'M' | 'F'
+  gender: 'M' | 'F' | 'O' | 'N' | 'P' | null
   total_revenue: number
   attributed_campaign: string
   attributed_source: string
@@ -79,11 +102,11 @@ interface Purchase {
 interface Device {
   model: string
   os: string
-  carrier: string | null
+  carrier?: string | null
   device_id?: string
   idfv?: string
-  idfa?: string
-  google_ad_id?: string
+  idfa?: string | null
+  google_ad_id?: string | null
   roku_ad_id?: string
   windows_ad_id?: string
   ad_tracking_enabled: boolean
@@ -143,11 +166,12 @@ interface CanvasReceived {
  * The following is a list of valid `fields_to_export`.
  *
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#fields-to-export}
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/#fields-to-export}
  */
 type FieldsToExport =
   | 'apps'
   | 'attributed_campaign'
-  | 'attributed_campaign'
+  | 'attributed_source'
   | 'attributed_adgroup'
   | 'attributed_ad'
   | 'braze_id'


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add users export segment

https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/

Rename types:

- `UsersExportsIdsObject` -> `UsersExportIdsObject`
- `UsersExportsIdsResposne` -> `UsersExportIdsResponse`

## What is the current behavior?

No way to export all the users within a segment

## What is the new behavior?

Method to export all the users within a segment: `braze.users.export.segment()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation