### PR TITLE
feat: add users export Global Control Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 
 - [x] /users/alias/new
 - [x] /users/delete
-- [ ] /users/export/global_control_group
+- [x] /users/export/global_control_group
 - [x] /users/export/ids
 - [x] /users/export/segment
 - [x] /users/external_ids/rename

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -6,6 +6,7 @@ import type {
   TransactionalV1CampaignsSendObject,
   UsersAliasObject,
   UsersDeleteObject,
+  UsersExportGlobalControlGroupObject,
   UsersExportIdsObject,
   UsersExportSegmentObject,
   UsersExternalIdsRemoveObject,
@@ -115,6 +116,15 @@ it('calls users.delete()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.users.delete(body as UsersDeleteObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/delete`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls users.export.global_control_group()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.users.export.global_control_group(body as UsersExportGlobalControlGroupObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/users/export/global_control_group`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -77,6 +77,9 @@ export class Braze {
     delete: (body: users.UsersDeleteObject) => users._delete(this.apiUrl, this.apiKey, body),
 
     export: {
+      global_control_group: (body: users.export.UsersExportGlobalControlGroupObject) =>
+        users.export.global_control_group(this.apiUrl, this.apiKey, body),
+
       ids: (body: users.export.UsersExportIdsObject) =>
         users.export.ids(this.apiUrl, this.apiKey, body),
 

--- a/src/users/export/global_control_group.test.ts
+++ b/src/users/export/global_control_group.test.ts
@@ -1,0 +1,42 @@
+import { post } from '../../common/request'
+import { global_control_group } from '.'
+import type {
+  UsersExportGlobalControlGroupObject,
+  UsersExportGlobalControlGroupResponse,
+} from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/users/export/global_control_group', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const body: UsersExportGlobalControlGroupObject = {
+    callback_endpoint: '',
+    fields_to_export: ['email', 'braze_id'],
+    output_format: 'zip',
+  }
+
+  const data: UsersExportGlobalControlGroupResponse = {
+    message: 'success',
+    object_prefix: 'bb8e2a91-c4aa-478b-b3f2-a4ee91731ad1-1464728599',
+    url: 'https://example.com/',
+  }
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await global_control_group(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/users/export/global_control_group`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/users/export/global_control_group.ts
+++ b/src/users/export/global_control_group.ts
@@ -1,0 +1,36 @@
+import { post } from '../../common/request'
+import type {
+  UsersExportGlobalControlGroupObject,
+  UsersExportGlobalControlGroupResponse,
+} from './types'
+
+/**
+ * Users by Global Control Group.
+ *
+ * This endpoint allows you to export all the users within the Global Control Group.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_global_control_group/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function global_control_group(
+  apiUrl: string,
+  apiKey: string,
+  body: UsersExportGlobalControlGroupObject,
+) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(
+    `${apiUrl}/users/export/global_control_group`,
+    body,
+    options,
+  ) as Promise<UsersExportGlobalControlGroupResponse>
+}

--- a/src/users/export/index.ts
+++ b/src/users/export/index.ts
@@ -1,3 +1,4 @@
+export * from './global_control_group'
 export * from './ids'
 export * from './segment'
 export * from './types'

--- a/src/users/export/types.ts
+++ b/src/users/export/types.ts
@@ -1,6 +1,28 @@
 import type { UserAlias } from '../../common/types'
 
 /**
+ * Request body for users by Global Control Group.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_global_control_group/#request-body}
+ */
+export interface UsersExportGlobalControlGroupObject {
+  callback_endpoint?: string
+  fields_to_export: FieldsToExport[]
+  output_format?: 'zip' | 'gzip'
+}
+
+/**
+ * Response body for users by Global Control Group.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_global_control_group/#response}
+ */
+export interface UsersExportGlobalControlGroupResponse {
+  message: 'success' | string
+  object_prefix: string
+  url?: string
+}
+
+/**
  * Request body for users by identifier endpoint.
  *
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#request-body}
@@ -21,7 +43,7 @@ export interface UsersExportIdsObject {
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_identifier/#response}
  */
 export interface UsersExportIdsResponse {
-  message: string
+  message: 'success' | string
   users: Partial<UserExportObject>[]
   invalid_user_ids?: string[]
 }
@@ -44,7 +66,7 @@ export interface UsersExportSegmentObject {
  * {@link https://www.braze.com/docs/api/endpoints/export/user_data/post_users_segment/#response}
  */
 export interface UsersExportSegmentResponse {
-  message: string
+  message: 'success' | string
   object_prefix: string
   url?: string
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add users export Global Control Group

https://www.braze.com/docs/api/endpoints/export/user_data/post_users_global_control_group/

## What is the current behavior?

No way to export all the users within the Global Control Group

## What is the new behavior?

Method to export all the users within the Global Control Group: `braze.users.export.global_control_group()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation