### PR TITLE
feat: add campaigns trigger schedule create

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 
 ### Schedule messages
 
-- [ ] /campaigns/trigger/schedule/create
+- [x] /campaigns/trigger/schedule/create
 - [ ] /campaigns/trigger/schedule/delete
 - [ ] /campaigns/trigger/schedule/update
 - [ ] /canvas/trigger/schedule/create

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -1,4 +1,5 @@
 import type {
+  CampaignsTriggerScheduleCreateObject,
   CampaignsTriggerSendObject,
   CanvasTriggerSendObject,
   MessagesSendObject,
@@ -59,6 +60,15 @@ const options = {
   method: expect.stringMatching(/^GET|POST$/),
 }
 const response = {}
+
+it('calls campaigns.trigger.schedule.create()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.campaigns.trigger.schedule.create(body as CampaignsTriggerScheduleCreateObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/create`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
 
 it('calls campaigns.trigger.send()', async () => {
   mockedRequest.mockResolvedValueOnce(response)

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -35,6 +35,11 @@ export class Braze {
 
   campaigns = {
     trigger: {
+      schedule: {
+        create: (body: campaigns.trigger.schedule.CampaignsTriggerScheduleCreateObject) =>
+          campaigns.trigger.schedule.create(this.apiUrl, this.apiKey, body),
+      },
+
       send: (body: campaigns.trigger.CampaignsTriggerSendObject) =>
         campaigns.trigger.send(this.apiUrl, this.apiKey, body),
     },

--- a/src/campaigns/trigger/index.ts
+++ b/src/campaigns/trigger/index.ts
@@ -1,2 +1,3 @@
+export * as schedule from './schedule'
 export * from './send'
 export * from './types'

--- a/src/campaigns/trigger/schedule/create.test.ts
+++ b/src/campaigns/trigger/schedule/create.test.ts
@@ -1,0 +1,98 @@
+import { post } from '../../../common/request'
+import { create } from '.'
+import type { CampaignsTriggerScheduleCreateObject } from './types'
+
+jest.mock('../../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/campaigns/trigger/schedule/create', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const body: CampaignsTriggerScheduleCreateObject = {
+    campaign_id: 'campaign_identifier',
+    send_id: 'send_identifier',
+    recipients: [
+      {
+        user_alias: {
+          alias_name: 'user_alias_name',
+          alias_label: 'user_alias_label',
+        },
+        external_user_id: 'external_user_identifier',
+        trigger_properties: {},
+      },
+    ],
+    audience: {
+      AND: [
+        {
+          custom_attribute: {
+            custom_attribute_name: 'eye_color',
+            comparison: 'equals',
+            value: 'blue',
+          },
+        },
+        {
+          custom_attribute: {
+            custom_attribute_name: 'favorite_foods',
+            comparison: 'includes_value',
+            value: 'pizza',
+          },
+        },
+        {
+          OR: [
+            {
+              custom_attribute: {
+                custom_attribute_name: 'last_purchase_time',
+                comparison: 'less_than_x_days_ago',
+                value: 2,
+              },
+            },
+            {
+              push_subscription_status: {
+                comparison: 'is',
+                value: 'opted_in',
+              },
+            },
+          ],
+        },
+        {
+          email_subscription_status: {
+            comparison: 'is_not',
+            value: 'subscribed',
+          },
+        },
+        {
+          last_used_app: {
+            comparison: 'after',
+            value: '2019-07-22T13:17:55+0000',
+          },
+        },
+      ],
+    },
+    broadcast: false,
+    trigger_properties: {},
+    schedule: {
+      time: '',
+      in_local_time: false,
+      at_optimal_time: false,
+    },
+  }
+
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await create(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/create`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/campaigns/trigger/schedule/create.ts
+++ b/src/campaigns/trigger/schedule/create.ts
@@ -1,0 +1,25 @@
+import { post } from '../../../common/request'
+import type { CampaignsTriggerScheduleCreateObject } from './types'
+
+/**
+ * Schedule API-triggered campaigns.
+ *
+ * Use this endpoint to trigger API-triggered campaigns, which are created on the dashboard and initiated via the API.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function create(apiUrl: string, apiKey: string, body: CampaignsTriggerScheduleCreateObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/campaigns/trigger/schedule/create`, body, options)
+}

--- a/src/campaigns/trigger/schedule/index.ts
+++ b/src/campaigns/trigger/schedule/index.ts
@@ -1,0 +1,2 @@
+export * from './create'
+export * from './types'

--- a/src/campaigns/trigger/schedule/types.ts
+++ b/src/campaigns/trigger/schedule/types.ts
@@ -1,0 +1,14 @@
+import type { CampaignsTriggerSendObject } from '../types'
+
+/**
+ * Request body for schedule API-triggered campaigns.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns/#request-body}
+ */
+export interface CampaignsTriggerScheduleCreateObject extends CampaignsTriggerSendObject {
+  schedule: {
+    time?: string
+    in_local_time?: boolean
+    at_optimal_time?: boolean
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from './Braze'
+export * from './campaigns/trigger/schedule/types'
 export * from './campaigns/trigger/types'
 export * from './canvas/trigger/types'
 export * from './common/types'


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add campaigns trigger schedule create

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns/

## What is the current behavior?

No way to schedule API-triggered campaigns

## What is the new behavior?

Method to schedule API-triggered campaigns: `braze.campaigns.trigger.schedule.create()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation