### PR TITLE
feat: add campaigns trigger schedule delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 ### Schedule messages
 
 - [x] /campaigns/trigger/schedule/create
-- [ ] /campaigns/trigger/schedule/delete
+- [x] /campaigns/trigger/schedule/delete
 - [ ] /campaigns/trigger/schedule/update
 - [ ] /canvas/trigger/schedule/create
 - [ ] /canvas/trigger/schedule/delete

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -1,5 +1,6 @@
 import type {
   CampaignsTriggerScheduleCreateObject,
+  CampaignsTriggerScheduleDeleteObject,
   CampaignsTriggerSendObject,
   CanvasTriggerSendObject,
   MessagesSendObject,
@@ -67,6 +68,15 @@ it('calls campaigns.trigger.schedule.create()', async () => {
     await braze.campaigns.trigger.schedule.create(body as CampaignsTriggerScheduleCreateObject),
   ).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/create`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls campaigns.trigger.schedule.delete()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.campaigns.trigger.schedule.delete(body as CampaignsTriggerScheduleDeleteObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/delete`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -38,6 +38,9 @@ export class Braze {
       schedule: {
         create: (body: campaigns.trigger.schedule.CampaignsTriggerScheduleCreateObject) =>
           campaigns.trigger.schedule.create(this.apiUrl, this.apiKey, body),
+
+        delete: (body: campaigns.trigger.schedule.CampaignsTriggerScheduleDeleteObject) =>
+          campaigns.trigger.schedule._delete(this.apiUrl, this.apiKey, body),
       },
 
       send: (body: campaigns.trigger.CampaignsTriggerSendObject) =>

--- a/src/campaigns/trigger/schedule/create.ts
+++ b/src/campaigns/trigger/schedule/create.ts
@@ -21,5 +21,8 @@ export function create(apiUrl: string, apiKey: string, body: CampaignsTriggerSch
     },
   }
 
-  return post(`${apiUrl}/campaigns/trigger/schedule/create`, body, options)
+  return post(`${apiUrl}/campaigns/trigger/schedule/create`, body, options) as Promise<{
+    dispatch_id: string
+    schedule_id: string
+  }>
 }

--- a/src/campaigns/trigger/schedule/delete.test.ts
+++ b/src/campaigns/trigger/schedule/delete.test.ts
@@ -1,0 +1,32 @@
+import { post } from '../../../common/request'
+import { _delete } from '.'
+import type { CampaignsTriggerScheduleDeleteObject } from './types'
+
+jest.mock('../../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/campaigns/trigger/schedule/delete', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CampaignsTriggerScheduleDeleteObject = {
+    campaign_id: 'campaign_identifier',
+    schedule_id: 'schedule_identifier',
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await _delete(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/delete`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/campaigns/trigger/schedule/delete.ts
+++ b/src/campaigns/trigger/schedule/delete.ts
@@ -1,0 +1,29 @@
+import { post } from '../../../common/request'
+import type { CampaignsTriggerScheduleDeleteObject } from './types'
+
+/**
+ * Delete scheduled API-triggered campaigns.
+ *
+ * The delete schedule endpoint allows you to cancel a message that you previously scheduled API-triggered campaigns before it has been sent.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function _delete(
+  apiUrl: string,
+  apiKey: string,
+  body: CampaignsTriggerScheduleDeleteObject,
+) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/campaigns/trigger/schedule/delete`, body, options)
+}

--- a/src/campaigns/trigger/schedule/index.ts
+++ b/src/campaigns/trigger/schedule/index.ts
@@ -1,2 +1,3 @@
 export * from './create'
+export * from './delete'
 export * from './types'

--- a/src/campaigns/trigger/schedule/types.ts
+++ b/src/campaigns/trigger/schedule/types.ts
@@ -7,8 +7,18 @@ import type { CampaignsTriggerSendObject } from '../types'
  */
 export interface CampaignsTriggerScheduleCreateObject extends CampaignsTriggerSendObject {
   schedule: {
-    time?: string
+    time: string
     in_local_time?: boolean
     at_optimal_time?: boolean
   }
+}
+
+/**
+ * Request body for delete scheduled API-triggered campaigns.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages/#request-body}
+ */
+export interface CampaignsTriggerScheduleDeleteObject {
+  campaign_id: string
+  schedule_id: string
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add campaigns trigger schedule delete

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_messages/

## What is the current behavior?

No method to cancel a message that was previously scheduled via API-triggered campaigns before it has been sent.

## What is the new behavior?

Method to cancel a message that was previously scheduled via API-triggered campaigns before it has been sent: `braze.campaigns.trigger.schedule.delete()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation