### PR TITLE
feat: add campaigns trigger schedule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 
 - [x] /campaigns/trigger/schedule/create
 - [x] /campaigns/trigger/schedule/delete
-- [ ] /campaigns/trigger/schedule/update
+- [x] /campaigns/trigger/schedule/update
 - [ ] /canvas/trigger/schedule/create
 - [ ] /canvas/trigger/schedule/delete
 - [ ] /canvas/trigger/schedule/update

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -1,6 +1,7 @@
 import type {
   CampaignsTriggerScheduleCreateObject,
   CampaignsTriggerScheduleDeleteObject,
+  CampaignsTriggerScheduleUpdateObject,
   CampaignsTriggerSendObject,
   CanvasTriggerSendObject,
   MessagesSendObject,
@@ -77,6 +78,15 @@ it('calls campaigns.trigger.schedule.delete()', async () => {
     await braze.campaigns.trigger.schedule.delete(body as CampaignsTriggerScheduleDeleteObject),
   ).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/delete`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls campaigns.trigger.schedule.update()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.campaigns.trigger.schedule.update(body as CampaignsTriggerScheduleUpdateObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/update`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -41,6 +41,9 @@ export class Braze {
 
         delete: (body: campaigns.trigger.schedule.CampaignsTriggerScheduleDeleteObject) =>
           campaigns.trigger.schedule._delete(this.apiUrl, this.apiKey, body),
+
+        update: (body: campaigns.trigger.schedule.CampaignsTriggerScheduleUpdateObject) =>
+          campaigns.trigger.schedule.update(this.apiUrl, this.apiKey, body),
       },
 
       send: (body: campaigns.trigger.CampaignsTriggerSendObject) =>

--- a/src/campaigns/trigger/schedule/index.ts
+++ b/src/campaigns/trigger/schedule/index.ts
@@ -1,3 +1,4 @@
 export * from './create'
 export * from './delete'
 export * from './types'
+export * from './update'

--- a/src/campaigns/trigger/schedule/types.ts
+++ b/src/campaigns/trigger/schedule/types.ts
@@ -6,11 +6,7 @@ import type { CampaignsTriggerSendObject } from '../types'
  * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns/#request-body}
  */
 export interface CampaignsTriggerScheduleCreateObject extends CampaignsTriggerSendObject {
-  schedule: {
-    time: string
-    in_local_time?: boolean
-    at_optimal_time?: boolean
-  }
+  schedule: Schedule
 }
 
 /**
@@ -21,4 +17,26 @@ export interface CampaignsTriggerScheduleCreateObject extends CampaignsTriggerSe
 export interface CampaignsTriggerScheduleDeleteObject {
   campaign_id: string
   schedule_id: string
+}
+
+/**
+ * Request body for update scheduled API-triggered campaigns.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns/#request-body}
+ */
+export interface CampaignsTriggerScheduleUpdateObject {
+  campaign_id: string
+  schedule_id: string
+  schedule: Schedule
+}
+
+/**
+ * Schedule object specification.
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/schedule_object/}
+ */
+interface Schedule {
+  time: string
+  in_local_time?: boolean
+  at_optimal_time?: boolean
 }

--- a/src/campaigns/trigger/schedule/update.test.ts
+++ b/src/campaigns/trigger/schedule/update.test.ts
@@ -1,0 +1,36 @@
+import { post } from '../../../common/request'
+import { update } from '.'
+import type { CampaignsTriggerScheduleUpdateObject } from './types'
+
+jest.mock('../../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/campaigns/trigger/schedule/update', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CampaignsTriggerScheduleUpdateObject = {
+    campaign_id: 'campaign_identifier',
+    schedule_id: 'schedule_identifier',
+    schedule: {
+      time: '2017-05-24T21:30:00Z',
+      in_local_time: true,
+    },
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await update(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/campaigns/trigger/schedule/update`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/campaigns/trigger/schedule/update.ts
+++ b/src/campaigns/trigger/schedule/update.ts
@@ -1,0 +1,25 @@
+import { post } from '../../../common/request'
+import type { CampaignsTriggerScheduleUpdateObject } from './types'
+
+/**
+ * Update scheduled API-triggered campaigns.
+ *
+ * Use this endpoint to update scheduled API-triggered campaigns, which are created on the dashboard and initiated via the API.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function update(apiUrl: string, apiKey: string, body: CampaignsTriggerScheduleUpdateObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/campaigns/trigger/schedule/update`, body, options)
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add campaigns trigger schedule update

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_campaigns/

## What is the current behavior?

No method to update scheduled API-triggered campaigns.

## What is the new behavior?

Method to update scheduled API-triggered campaigns: `braze.campaigns.trigger.schedule.update()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation