### PR TITLE
feat: add canvas trigger schedule create

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /campaigns/trigger/schedule/create
 - [x] /campaigns/trigger/schedule/delete
 - [x] /campaigns/trigger/schedule/update
-- [ ] /canvas/trigger/schedule/create
+- [x] /canvas/trigger/schedule/create
 - [ ] /canvas/trigger/schedule/delete
 - [ ] /canvas/trigger/schedule/update
 - [ ] /messages/schedule/create

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -3,6 +3,7 @@ import type {
   CampaignsTriggerScheduleDeleteObject,
   CampaignsTriggerScheduleUpdateObject,
   CampaignsTriggerSendObject,
+  CanvasTriggerScheduleCreateObject,
   CanvasTriggerSendObject,
   MessagesSendObject,
   SendsIdCreateObject,
@@ -94,6 +95,15 @@ it('calls campaigns.trigger.send()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.campaigns.trigger.send(body as CampaignsTriggerSendObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/campaigns/trigger/send`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls canvas.trigger.schedule.create()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.canvas.trigger.schedule.create(body as CanvasTriggerScheduleCreateObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/create`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -53,6 +53,11 @@ export class Braze {
 
   canvas = {
     trigger: {
+      schedule: {
+        create: (body: canvas.trigger.schedule.CanvasTriggerScheduleCreateObject) =>
+          canvas.trigger.schedule.create(this.apiUrl, this.apiKey, body),
+      },
+
       send: (body: canvas.trigger.CanvasTriggerSendObject) =>
         canvas.trigger.send(this.apiUrl, this.apiKey, body),
     },

--- a/src/campaigns/trigger/schedule/types.ts
+++ b/src/campaigns/trigger/schedule/types.ts
@@ -1,3 +1,4 @@
+import type { ScheduleObject } from '../../../common/types'
 import type { CampaignsTriggerSendObject } from '../types'
 
 /**
@@ -6,7 +7,7 @@ import type { CampaignsTriggerSendObject } from '../types'
  * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns/#request-body}
  */
 export interface CampaignsTriggerScheduleCreateObject extends CampaignsTriggerSendObject {
-  schedule: Schedule
+  schedule: ScheduleObject
 }
 
 /**
@@ -27,16 +28,5 @@ export interface CampaignsTriggerScheduleDeleteObject {
 export interface CampaignsTriggerScheduleUpdateObject {
   campaign_id: string
   schedule_id: string
-  schedule: Schedule
-}
-
-/**
- * Schedule object specification.
- *
- * {@link https://www.braze.com/docs/api/objects_filters/schedule_object/}
- */
-interface Schedule {
-  time: string
-  in_local_time?: boolean
-  at_optimal_time?: boolean
+  schedule: ScheduleObject
 }

--- a/src/canvas/trigger/index.ts
+++ b/src/canvas/trigger/index.ts
@@ -1,2 +1,3 @@
+export * as schedule from './schedule'
 export * from './send'
 export * from './types'

--- a/src/canvas/trigger/schedule/create.test.ts
+++ b/src/canvas/trigger/schedule/create.test.ts
@@ -1,0 +1,96 @@
+import { post } from '../../../common/request'
+import { create } from '.'
+import type { CanvasTriggerScheduleCreateObject } from './types'
+
+jest.mock('../../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/canvas/trigger/schedule/create', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CanvasTriggerScheduleCreateObject = {
+    canvas_id: 'canvas_identifier',
+    recipients: [
+      {
+        user_alias: {
+          alias_name: 'user_alias_name',
+          alias_label: 'user_alias_label',
+        },
+        external_user_id: 'external_user_identifier',
+        trigger_properties: {},
+        canvas_entry_properties: {},
+      },
+    ],
+    audience: {
+      AND: [
+        {
+          custom_attribute: {
+            custom_attribute_name: 'eye_color',
+            comparison: 'equals',
+            value: 'blue',
+          },
+        },
+        {
+          custom_attribute: {
+            custom_attribute_name: 'favorite_foods',
+            comparison: 'includes_value',
+            value: 'pizza',
+          },
+        },
+        {
+          OR: [
+            {
+              custom_attribute: {
+                custom_attribute_name: 'last_purchase_time',
+                comparison: 'less_than_x_days_ago',
+                value: 2,
+              },
+            },
+            {
+              push_subscription_status: {
+                comparison: 'is',
+                value: 'opted_in',
+              },
+            },
+          ],
+        },
+        {
+          email_subscription_status: {
+            comparison: 'is_not',
+            value: 'subscribed',
+          },
+        },
+        {
+          last_used_app: {
+            comparison: 'after',
+            value: '2019-07-22T13:17:55+0000',
+          },
+        },
+      ],
+    },
+    broadcast: false,
+    canvas_entry_properties: {},
+    schedule: {
+      time: '',
+      in_local_time: false,
+      at_optimal_time: false,
+    },
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await create(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/create`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/canvas/trigger/schedule/create.ts
+++ b/src/canvas/trigger/schedule/create.ts
@@ -1,0 +1,28 @@
+import { post } from '../../../common/request'
+import type { CanvasTriggerScheduleCreateObject } from './types'
+
+/**
+ * Schedule API-triggered canvases.
+ *
+ * Use this endpoint to trigger API-Triggered Canvases, which are created on the dashboard and initiated via the API.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function create(apiUrl: string, apiKey: string, body: CanvasTriggerScheduleCreateObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/canvas/trigger/schedule/create`, body, options) as Promise<{
+    dispatch_id: string
+    schedule_id: string
+  }>
+}

--- a/src/canvas/trigger/schedule/index.ts
+++ b/src/canvas/trigger/schedule/index.ts
@@ -1,0 +1,2 @@
+export * from './create'
+export * from './types'

--- a/src/canvas/trigger/schedule/types.ts
+++ b/src/canvas/trigger/schedule/types.ts
@@ -1,0 +1,11 @@
+import type { ScheduleObject } from '../../../common/types'
+import type { CanvasTriggerSendObject } from '../types'
+
+/**
+ * Request body for schedule API-triggered canvases.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases/#request-body}
+ */
+export interface CanvasTriggerScheduleCreateObject extends CanvasTriggerSendObject {
+  schedule: ScheduleObject
+}

--- a/src/canvas/trigger/types.ts
+++ b/src/canvas/trigger/types.ts
@@ -1,4 +1,9 @@
-import type { Attributes, ConnectedAudienceObject, UserAlias } from '../../common/types'
+import type {
+  Attributes,
+  ConnectedAudienceObject,
+  TriggerProperties,
+  UserAlias,
+} from '../../common/types'
 
 /**
  * Request body for sending Canvas messages via API-triggered delivery.
@@ -19,6 +24,7 @@ interface Recipient {
   canvas_entry_properties?: CanvasEntryProperties
   send_to_existing_only?: boolean
   attributes?: Attributes
+  trigger_properties?: TriggerProperties
 }
 
 interface RecipientWithExternalUserId extends Recipient {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -59,3 +59,14 @@ export interface UserAlias {
   alias_name: string
   alias_label: string
 }
+
+/**
+ * Schedule object specification.
+ *
+ * {@link https://www.braze.com/docs/api/objects_filters/schedule_object/}
+ */
+export interface ScheduleObject {
+  time: string
+  in_local_time?: boolean
+  at_optimal_time?: boolean
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Braze'
 export * from './campaigns/trigger/schedule/types'
 export * from './campaigns/trigger/types'
+export * from './canvas/trigger/schedule/types'
 export * from './canvas/trigger/types'
 export * from './common/types'
 export * from './messages/types'


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add canvas trigger schedule create

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases/

## What is the current behavior?

No method to schedule Canvas messages (up to 90 days in advance) via API-Triggered delivery.

## What is the new behavior?

Method to schedule Canvas messages (up to 90 days in advance) via API-Triggered delivery: `braze.canvas.trigger.schedule.create()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation