### PR TITLE
feat: add canvas trigger schedule delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /campaigns/trigger/schedule/delete
 - [x] /campaigns/trigger/schedule/update
 - [x] /canvas/trigger/schedule/create
-- [ ] /canvas/trigger/schedule/delete
+- [x] /canvas/trigger/schedule/delete
 - [ ] /canvas/trigger/schedule/update
 - [ ] /messages/schedule/create
 - [ ] /messages/schedule/delete

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -4,6 +4,7 @@ import type {
   CampaignsTriggerScheduleUpdateObject,
   CampaignsTriggerSendObject,
   CanvasTriggerScheduleCreateObject,
+  CanvasTriggerScheduleDeleteObject,
   CanvasTriggerSendObject,
   MessagesSendObject,
   SendsIdCreateObject,
@@ -104,6 +105,15 @@ it('calls canvas.trigger.schedule.create()', async () => {
     await braze.canvas.trigger.schedule.create(body as CanvasTriggerScheduleCreateObject),
   ).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/create`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls canvas.trigger.schedule.delete()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.canvas.trigger.schedule.delete(body as CanvasTriggerScheduleDeleteObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/delete`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -56,6 +56,9 @@ export class Braze {
       schedule: {
         create: (body: canvas.trigger.schedule.CanvasTriggerScheduleCreateObject) =>
           canvas.trigger.schedule.create(this.apiUrl, this.apiKey, body),
+
+        delete: (body: canvas.trigger.schedule.CanvasTriggerScheduleDeleteObject) =>
+          canvas.trigger.schedule._delete(this.apiUrl, this.apiKey, body),
       },
 
       send: (body: canvas.trigger.CanvasTriggerSendObject) =>

--- a/src/canvas/trigger/schedule/delete.test.ts
+++ b/src/canvas/trigger/schedule/delete.test.ts
@@ -1,0 +1,32 @@
+import { post } from '../../../common/request'
+import { _delete } from '.'
+import type { CanvasTriggerScheduleDeleteObject } from './types'
+
+jest.mock('../../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/canvas/trigger/schedule/delete', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CanvasTriggerScheduleDeleteObject = {
+    canvas_id: 'canvas_identifier',
+    schedule_id: 'schedule_identifier',
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await _delete(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/delete`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/canvas/trigger/schedule/delete.ts
+++ b/src/canvas/trigger/schedule/delete.ts
@@ -1,0 +1,25 @@
+import { post } from '../../../common/request'
+import type { CanvasTriggerScheduleDeleteObject } from './types'
+
+/**
+ * Delete scheduled API-triggered canvases.
+ *
+ * The delete schedule endpoint allows you to cancel a message that you previously scheduled API-triggered Canvases before it has been sent.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function _delete(apiUrl: string, apiKey: string, body: CanvasTriggerScheduleDeleteObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/canvas/trigger/schedule/delete`, body, options)
+}

--- a/src/canvas/trigger/schedule/index.ts
+++ b/src/canvas/trigger/schedule/index.ts
@@ -1,2 +1,3 @@
 export * from './create'
+export * from './delete'
 export * from './types'

--- a/src/canvas/trigger/schedule/types.ts
+++ b/src/canvas/trigger/schedule/types.ts
@@ -9,3 +9,13 @@ import type { CanvasTriggerSendObject } from '../types'
 export interface CanvasTriggerScheduleCreateObject extends CanvasTriggerSendObject {
   schedule: ScheduleObject
 }
+
+/**
+ * Request body for delete scheduled API-triggered canvases.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases/#request-body}
+ */
+export interface CanvasTriggerScheduleDeleteObject {
+  canvas_id: string
+  schedule_id: string
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add canvas trigger schedule delete

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_triggered_canvases/

## What is the current behavior?

No method to cancel a message that was previously scheduled via API-triggered Canvases

## What is the new behavior?

Method to cancel a message that was previously scheduled via API-triggered Canvases: `braze.canvas.trigger.schedule.delete()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation