### PR TITLE
feat: add canvas trigger schedule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /campaigns/trigger/schedule/update
 - [x] /canvas/trigger/schedule/create
 - [x] /canvas/trigger/schedule/delete
-- [ ] /canvas/trigger/schedule/update
+- [x] /canvas/trigger/schedule/update
 - [ ] /messages/schedule/create
 - [ ] /messages/schedule/delete
 - [ ] /messages/schedule/update

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -5,6 +5,7 @@ import type {
   CampaignsTriggerSendObject,
   CanvasTriggerScheduleCreateObject,
   CanvasTriggerScheduleDeleteObject,
+  CanvasTriggerScheduleUpdateObject,
   CanvasTriggerSendObject,
   MessagesSendObject,
   SendsIdCreateObject,
@@ -114,6 +115,15 @@ it('calls canvas.trigger.schedule.delete()', async () => {
     await braze.canvas.trigger.schedule.delete(body as CanvasTriggerScheduleDeleteObject),
   ).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/delete`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls canvas.trigger.schedule.update()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(
+    await braze.canvas.trigger.schedule.update(body as CanvasTriggerScheduleUpdateObject),
+  ).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/update`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -59,6 +59,9 @@ export class Braze {
 
         delete: (body: canvas.trigger.schedule.CanvasTriggerScheduleDeleteObject) =>
           canvas.trigger.schedule._delete(this.apiUrl, this.apiKey, body),
+
+        update: (body: canvas.trigger.schedule.CanvasTriggerScheduleUpdateObject) =>
+          canvas.trigger.schedule.update(this.apiUrl, this.apiKey, body),
       },
 
       send: (body: canvas.trigger.CanvasTriggerSendObject) =>

--- a/src/canvas/trigger/schedule/index.ts
+++ b/src/canvas/trigger/schedule/index.ts
@@ -1,3 +1,4 @@
 export * from './create'
 export * from './delete'
 export * from './types'
+export * from './update'

--- a/src/canvas/trigger/schedule/types.ts
+++ b/src/canvas/trigger/schedule/types.ts
@@ -19,3 +19,14 @@ export interface CanvasTriggerScheduleDeleteObject {
   canvas_id: string
   schedule_id: string
 }
+
+/**
+ * Request body for update scheduled API-triggered canvases.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases/#request-body}
+ */
+export interface CanvasTriggerScheduleUpdateObject {
+  canvas_id: string
+  schedule_id: string
+  schedule: ScheduleObject
+}

--- a/src/canvas/trigger/schedule/update.test.ts
+++ b/src/canvas/trigger/schedule/update.test.ts
@@ -1,0 +1,36 @@
+import { post } from '../../../common/request'
+import { update } from '.'
+import type { CanvasTriggerScheduleUpdateObject } from './types'
+
+jest.mock('../../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/canvas/trigger/schedule/update', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: CanvasTriggerScheduleUpdateObject = {
+    canvas_id: 'canvas_identifier',
+    schedule_id: 'schedule_identifier',
+    schedule: {
+      time: '2017-05-24T21:30:00Z',
+      in_local_time: true,
+    },
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await update(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/canvas/trigger/schedule/update`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/canvas/trigger/schedule/update.ts
+++ b/src/canvas/trigger/schedule/update.ts
@@ -1,0 +1,25 @@
+import { post } from '../../../common/request'
+import type { CanvasTriggerScheduleUpdateObject } from './types'
+
+/**
+ * Update scheduled API-triggered canvases.
+ *
+ * Use this endpoint to update scheduled API-Triggered Canvases, which are created on the dashboard and initiated via the API.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function update(apiUrl: string, apiKey: string, body: CanvasTriggerScheduleUpdateObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/canvas/trigger/schedule/update`, body, options)
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add canvas trigger schedule update

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_triggered_canvases/

## What is the current behavior?

No method to update scheduled API-Triggered Canvases

## What is the new behavior?

Method to update scheduled API-Triggered Canvases: `braze.canvas.trigger.schedule.update()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation