### PR TITLE
feat: add messages schedule delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /canvas/trigger/schedule/delete
 - [x] /canvas/trigger/schedule/update
 - [x] /messages/schedule/create
-- [ ] /messages/schedule/delete
+- [x] /messages/schedule/delete
 - [ ] /messages/schedule/update
 - [ ] /messages/scheduled_broadcasts
 

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -8,6 +8,7 @@ import type {
   CanvasTriggerScheduleUpdateObject,
   CanvasTriggerSendObject,
   MessagesScheduleCreateObject,
+  MessagesScheduleDeleteObject,
   MessagesSendObject,
   SendsIdCreateObject,
   TransactionalV1CampaignsSendObject,
@@ -139,6 +140,13 @@ it('calls messages.schedule.create()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.messages.schedule.create(body as MessagesScheduleCreateObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/messages/schedule/create`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls messages.schedule.delete()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.messages.schedule.delete(body as MessagesScheduleDeleteObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/messages/schedule/delete`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -73,6 +73,9 @@ export class Braze {
     schedule: {
       create: (body: messages.schedule.MessagesScheduleCreateObject) =>
         messages.schedule.create(this.apiUrl, this.apiKey, body),
+
+      delete: (body: messages.schedule.MessagesScheduleDeleteObject) =>
+        messages.schedule._delete(this.apiUrl, this.apiKey, body),
     },
 
     send: (body: messages.MessagesSendObject) => messages.send(this.apiUrl, this.apiKey, body),

--- a/src/messages/schedule/delete.test.ts
+++ b/src/messages/schedule/delete.test.ts
@@ -1,0 +1,31 @@
+import { post } from '../../common/request'
+import { _delete } from '.'
+import type { MessagesScheduleDeleteObject } from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/messages/schedule/delete', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body: MessagesScheduleDeleteObject = {
+    schedule_id: 'schedule_identifier',
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await _delete(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/messages/schedule/delete`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/messages/schedule/delete.ts
+++ b/src/messages/schedule/delete.ts
@@ -1,0 +1,25 @@
+import { post } from '../../common/request'
+import type { MessagesScheduleDeleteObject } from './types'
+
+/**
+ * Delete scheduled messages.
+ *
+ * The delete scheduled messages endpoint allows you to cancel a message that you previously scheduled before it has been sent.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function _delete(apiUrl: string, apiKey: string, body: MessagesScheduleDeleteObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/messages/schedule/delete`, body, options)
+}

--- a/src/messages/schedule/index.ts
+++ b/src/messages/schedule/index.ts
@@ -1,2 +1,3 @@
 export * from './create'
+export * from './delete'
 export * from './types'

--- a/src/messages/schedule/types.ts
+++ b/src/messages/schedule/types.ts
@@ -11,3 +11,12 @@ export interface MessagesScheduleCreateObject
   override_messaging_limits?: boolean
   schedule: ScheduleObject
 }
+
+/**
+ * Request body for delete scheduled messages.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages/#request-body}
+ */
+export interface MessagesScheduleDeleteObject {
+  schedule_id: string
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add messages schedule delete

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_delete_scheduled_messages/

## What is the current behavior?

No method to cancel a message that was previously scheduled before it has been sent

## What is the new behavior?

Method to cancel a message that was previously scheduled before it has been sent: `braze.messages.schedule.delete()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation