### PR TITLE
feat: add messages schedule update

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /canvas/trigger/schedule/update
 - [x] /messages/schedule/create
 - [x] /messages/schedule/delete
-- [ ] /messages/schedule/update
+- [x] /messages/schedule/update
 - [ ] /messages/scheduled_broadcasts
 
 ### Subscription groups

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -9,6 +9,7 @@ import type {
   CanvasTriggerSendObject,
   MessagesScheduleCreateObject,
   MessagesScheduleDeleteObject,
+  MessagesScheduleUpdateObject,
   MessagesSendObject,
   SendsIdCreateObject,
   TransactionalV1CampaignsSendObject,
@@ -147,6 +148,13 @@ it('calls messages.schedule.delete()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.messages.schedule.delete(body as MessagesScheduleDeleteObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/messages/schedule/delete`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls messages.schedule.update()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.messages.schedule.update(body as MessagesScheduleUpdateObject)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(`${apiUrl}/messages/schedule/update`, body, options)
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -76,6 +76,9 @@ export class Braze {
 
       delete: (body: messages.schedule.MessagesScheduleDeleteObject) =>
         messages.schedule._delete(this.apiUrl, this.apiKey, body),
+
+      update: (body: messages.schedule.MessagesScheduleUpdateObject) =>
+        messages.schedule.update(this.apiUrl, this.apiKey, body),
     },
 
     send: (body: messages.MessagesSendObject) => messages.send(this.apiUrl, this.apiKey, body),

--- a/src/messages/schedule/index.ts
+++ b/src/messages/schedule/index.ts
@@ -1,3 +1,4 @@
 export * from './create'
 export * from './delete'
 export * from './types'
+export * from './update'

--- a/src/messages/schedule/types.ts
+++ b/src/messages/schedule/types.ts
@@ -1,5 +1,5 @@
 import type { ScheduleObject } from '../../common/types'
-import type { MessagesSendObject } from '../types'
+import type { MessagesObject, MessagesSendObject } from '../types'
 
 /**
  * Request body for create scheduled messages.
@@ -19,4 +19,15 @@ export interface MessagesScheduleCreateObject
  */
 export interface MessagesScheduleDeleteObject {
   schedule_id: string
+}
+
+/**
+ * Request body for update scheduled messages.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_messages/#request-body}
+ */
+export interface MessagesScheduleUpdateObject {
+  schedule_id: string
+  schedule?: ScheduleObject
+  messages?: MessagesObject
 }

--- a/src/messages/schedule/update.test.ts
+++ b/src/messages/schedule/update.test.ts
@@ -1,0 +1,52 @@
+import { post } from '../../common/request'
+import { update } from '.'
+import type { MessagesScheduleUpdateObject } from './types'
+
+jest.mock('../../common/request')
+const mockedPost = jest.mocked(post)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/messages/schedule/update', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+
+  const body: MessagesScheduleUpdateObject = {
+    schedule_id: 'schedule_identifier',
+    schedule: {
+      time: '2017-05-24T20:30:36Z',
+    },
+    messages: {
+      apple_push: {
+        alert: 'Updated Message!',
+        badge: 1,
+      },
+      android_push: {
+        title: 'Updated title!',
+        alert: 'Updated message!',
+      },
+      sms: {
+        subscription_group_id: 'subscription_group_identifier',
+        message_variation_id: 'message_variation_identifier',
+        body: 'This is my SMS body.',
+        app_id: 'app_identifier',
+      },
+    },
+  }
+
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedPost.mockResolvedValueOnce(data)
+    expect(await update(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedPost).toBeCalledWith(`${apiUrl}/messages/schedule/update`, body, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    expect(mockedPost).toBeCalledTimes(1)
+  })
+})

--- a/src/messages/schedule/update.ts
+++ b/src/messages/schedule/update.ts
@@ -1,0 +1,25 @@
+import { post } from '../../common/request'
+import type { MessagesScheduleUpdateObject } from './types'
+
+/**
+ * Update scheduled messages.
+ *
+ * The messages update schedule endpoint accepts updates to either the `schedule` or `messages` parameter or both.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_messages/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function update(apiUrl: string, apiKey: string, body: MessagesScheduleUpdateObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/messages/schedule/update`, body, options)
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add messages schedule update

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_update_scheduled_messages/

## What is the current behavior?

No method to update scheduled messages

## What is the new behavior?

Method to update scheduled messages: `braze.messages.schedule.update()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation