### PR TITLE
feat: add messages scheduled_broadcasts

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 - [x] /messages/schedule/create
 - [x] /messages/schedule/delete
 - [x] /messages/schedule/update
-- [ ] /messages/scheduled_broadcasts
+- [x] /messages/scheduled_broadcasts
 
 ### Subscription groups
 

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -158,6 +158,17 @@ it('calls messages.schedule.update()', async () => {
   expect(mockedRequest).toBeCalledTimes(1)
 })
 
+it('calls messages.scheduled_broadcasts()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  expect(await braze.messages.scheduled_broadcasts({ end_time: '2022-08-21' })).toBe(response)
+  expect(mockedRequest).toBeCalledWith(
+    `${apiUrl}/messages/scheduled_broadcasts?end_time=2022-08-21`,
+    body,
+    { headers: options.headers },
+  )
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
 it('calls messages.send()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.messages.send(body as MessagesSendObject)).toBe(response)

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -81,6 +81,9 @@ export class Braze {
         messages.schedule.update(this.apiUrl, this.apiKey, body),
     },
 
+    scheduled_broadcasts: (body: Parameters<typeof messages.scheduled_broadcasts>[2]) =>
+      messages.scheduled_broadcasts(this.apiUrl, this.apiKey, body),
+
     send: (body: messages.MessagesSendObject) => messages.send(this.apiUrl, this.apiKey, body),
   }
 

--- a/src/common/request/get.test.ts
+++ b/src/common/request/get.test.ts
@@ -1,0 +1,7 @@
+import { get, request } from '.'
+
+describe('get', () => {
+  it('calls request', async () => {
+    expect(get).toBe(request)
+  })
+})

--- a/src/common/request/get.ts
+++ b/src/common/request/get.ts
@@ -1,0 +1,6 @@
+import { request } from './request'
+
+/**
+ * Sends a get request.
+ */
+export const get = request

--- a/src/common/request/index.ts
+++ b/src/common/request/index.ts
@@ -1,2 +1,3 @@
+export * from './get'
 export * from './post'
 export * from './request'

--- a/src/messages/index.ts
+++ b/src/messages/index.ts
@@ -1,3 +1,4 @@
 export * as schedule from './schedule'
+export * from './scheduled_broadcasts'
 export * from './send'
 export * from './types'

--- a/src/messages/scheduled_broadcasts.test.ts
+++ b/src/messages/scheduled_broadcasts.test.ts
@@ -1,0 +1,34 @@
+import { get } from '../common/request'
+import { scheduled_broadcasts } from '.'
+
+jest.mock('../common/request')
+const mockedGet = jest.mocked(get)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/messages/scheduled_broadcasts', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const body = {
+    end_time: '2018-09-01T00:00:00-04:00',
+  }
+  const data = {}
+
+  it('calls request with url and body', async () => {
+    mockedGet.mockResolvedValueOnce(data)
+    expect(await scheduled_broadcasts(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/messages/scheduled_broadcasts?end_time=2018-09-01T00%3A00%3A00-04%3A00`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+})

--- a/src/messages/scheduled_broadcasts.ts
+++ b/src/messages/scheduled_broadcasts.ts
@@ -1,0 +1,37 @@
+import { get } from '../common/request'
+
+/**
+ * Get upcoming scheduled campaigns and Canvases.
+ *
+ * The endpoint will return information about scheduled campaigns and entry Canvases between now and the designated `end_time` specified in the request.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/get_messages_scheduled/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function scheduled_broadcasts(apiUrl: string, apiKey: string, body: { end_time: string }) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return get(
+    `${apiUrl}/messages/scheduled_broadcasts?${new URLSearchParams(body)}`,
+    {},
+    options,
+  ) as Promise<{
+    scheduled_broadcasts: {
+      name: string
+      id: string
+      type: 'Canvas' | 'Campaign'
+      tags: string[]
+      next_send_time: string
+      schedule_type: 'local_time_zones' | 'intelligent_delivery' | string
+    }[]
+  }>
+}


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add messages scheduled_broadcasts

https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/get_messages_scheduled/

## What is the current behavior?

No method to get upcoming scheduled campaigns and Canvases

## What is the new behavior?

Method to get upcoming scheduled campaigns and Canvases: `braze.messages.scheduled_broadcasts()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation