### PR TITLE
feat: add subscription status get

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 
 - [x] /subscription/status/set
 - [x] /v2/subscription/status/set
-- [ ] /subscription/status/get
+- [x] /subscription/status/get
 - [ ] /subscription/user/status
 
 ### Email and email templates

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -12,6 +12,7 @@ import type {
   MessagesScheduleUpdateObject,
   MessagesSendObject,
   SendsIdCreateObject,
+  SubscriptionStatusGetObject,
   SubscriptionStatusSetObject,
   TransactionalV1CampaignsSendObject,
   UsersAliasObject,
@@ -165,7 +166,7 @@ it('calls messages.scheduled_broadcasts()', async () => {
   expect(await braze.messages.scheduled_broadcasts({ end_time: '2022-08-21' })).toBe(response)
   expect(mockedRequest).toBeCalledWith(
     `${apiUrl}/messages/scheduled_broadcasts?end_time=2022-08-21`,
-    body,
+    {},
     { headers: options.headers },
   )
   expect(mockedRequest).toBeCalledTimes(1)
@@ -182,6 +183,18 @@ it('calls sends.id.create()', async () => {
   mockedRequest.mockResolvedValueOnce(response)
   expect(await braze.sends.id.create(body as SendsIdCreateObject)).toBe(response)
   expect(mockedRequest).toBeCalledWith(`${apiUrl}/sends/id/create`, body, options)
+  expect(mockedRequest).toBeCalledTimes(1)
+})
+
+it('calls subscription.status.get()', async () => {
+  mockedRequest.mockResolvedValueOnce(response)
+  const body: SubscriptionStatusGetObject = { subscription_group_id: 'subscription_group_id' }
+  expect(await braze.subscription.status.get(body)).toBe(response)
+  expect(mockedRequest).toBeCalledWith(
+    `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id`,
+    {},
+    { headers: options.headers },
+  )
   expect(mockedRequest).toBeCalledTimes(1)
 })
 

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -98,6 +98,9 @@ export class Braze {
 
   subscription = {
     status: {
+      get: (body: subscription.status.SubscriptionStatusGetObject) =>
+        subscription.status.get(this.apiUrl, this.apiKey, body),
+
       set: (body: subscription.status.SubscriptionStatusSetObject) =>
         subscription.status.set(this.apiUrl, this.apiKey, body),
     },

--- a/src/subscription/status/get.test.ts
+++ b/src/subscription/status/get.test.ts
@@ -1,0 +1,76 @@
+import { get as _get } from '../../common/request'
+import { get } from '.'
+import type { SubscriptionStatusGetObject } from './types'
+
+jest.mock('../../common/request')
+const mockedGet = jest.mocked(_get)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('/subscription/status/get', () => {
+  const apiUrl = 'https://rest.iad-01.braze.com'
+  const apiKey = 'apiKey'
+  const data = {}
+
+  it('calls request for multiple users with url and body', async () => {
+    mockedGet.mockResolvedValueOnce(data)
+    const body: SubscriptionStatusGetObject = {
+      subscription_group_id: 'subscription_group_id',
+      external_id: ['1', '2'],
+    }
+    expect(await get(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id=1&external_id=2`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+
+  it('calls request for email with url and body', async () => {
+    mockedGet.mockResolvedValueOnce(data)
+    const body: SubscriptionStatusGetObject = {
+      subscription_group_id: 'subscription_group_id',
+      email: 'example@braze.com',
+    }
+    expect(await get(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email=example%40braze.com`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+
+  it('calls request for SMS with url and body', async () => {
+    mockedGet.mockResolvedValueOnce(data)
+    const body: SubscriptionStatusGetObject = {
+      subscription_group_id: 'subscription_group_id',
+      phone: '+11112223333',
+    }
+    expect(await get(apiUrl, apiKey, body)).toBe(data)
+    expect(mockedGet).toBeCalledWith(
+      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone=%2B11112223333`,
+      {},
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`,
+        },
+      },
+    )
+    expect(mockedGet).toBeCalledTimes(1)
+  })
+})

--- a/src/subscription/status/get.ts
+++ b/src/subscription/status/get.ts
@@ -1,0 +1,42 @@
+import { get as _get } from '../../common/request'
+import type { SubscriptionStatusGetObject } from './types'
+
+/**
+ * Get users’ subscription group status.
+ *
+ * Use these endpoints to get the subscription state of a user in a subscription group.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_group_status/}
+ *
+ * @param apiUrl - Braze REST endpoint.
+ * @param apiKey - Braze API key.
+ * @param body - Request parameters.
+ * @returns - Braze response.
+ */
+export function get(apiUrl: string, apiKey: string, body: SubscriptionStatusGetObject) {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  const params = new URLSearchParams()
+
+  if (body.subscription_group_id) {
+    params.append('subscription_group_id', body.subscription_group_id)
+  }
+
+  ;(['external_id', 'email', 'phone'] as const).forEach((key) => {
+    if (Array.isArray(body[key])) {
+      ;(body[key] as string[]).forEach((value) => params.append(key, value))
+    } else if (body[key]) {
+      params.append(key, body[key] as string)
+    }
+  })
+
+  return _get(`${apiUrl}/subscription/status/get?${params}`, {}, options) as Promise<{
+    status: Record<string, 'Subscribed' | 'Unsubscribed' | 'Unknown'>
+    message: 'success' | string
+  }>
+}

--- a/src/subscription/status/index.ts
+++ b/src/subscription/status/index.ts
@@ -1,2 +1,3 @@
+export * from './get'
 export * from './set'
 export * from './types'

--- a/src/subscription/status/types.ts
+++ b/src/subscription/status/types.ts
@@ -3,18 +3,32 @@
  *
  * {@link https://www.braze.com/docs/api/endpoints/subscription_groups/post_update_user_subscription_group_status/#request-body}
  */
-export type SubscriptionStatusSetObject = SubscriptionStatusWithPhone | SubscriptionStatusWithEmail
+export type SubscriptionStatusSetObject =
+  | SubscriptionStatusSetWithPhone
+  | SubscriptionStatusSetWithEmail
 
-interface SubscriptionStatus {
+/**
+ * Request body for get users’ subscription group status.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_group_status/#request-parameters}
+ */
+export type SubscriptionStatusGetObject = {
+  subscription_group_id: string
+  external_id?: string | string[]
+  email?: string | string[]
+  phone?: string | string[]
+}
+
+interface SubscriptionStatusSet {
   subscription_group_id: string
   subscription_state: 'unsubscribed' | 'subscribed'
   external_id: string[]
 }
 
-interface SubscriptionStatusWithPhone extends SubscriptionStatus {
+interface SubscriptionStatusSetWithPhone extends SubscriptionStatusSet {
   phone: string[]
 }
 
-interface SubscriptionStatusWithEmail extends SubscriptionStatus {
+interface SubscriptionStatusSetWithEmail extends SubscriptionStatusSet {
   email: string[]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

feat: add subscription status get

https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_group_status/

## What is the current behavior?

No method to get the subscription state of a user in a subscription group

## What is the new behavior?

Method to get the subscription state of a user in a subscription group: `braze.subscription.status.get()`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation