### PR TITLE
feat(content blocks): add list and get

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ This library currently supports a subset of the [Braze API endpoints](https://ww
 
 - [ ] /content_blocks/create
 - [ ] /content_blocks/update
-- [ ] /content_blocks/info
-- [ ] /content_blocks/list
+- [x] /content_blocks/info
+- [x] /content_blocks/list
 
 ### KPI
 

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -31,7 +31,7 @@ import type {
   V2SubscriptionStatusSetObject,
 } from '.'
 import { Braze } from '.'
-import { request } from './common/request'
+import { request, ServerResponse } from './common/request'
 
 jest.mock('./common/request/request')
 const mockedRequest = jest.mocked(request)
@@ -74,7 +74,7 @@ const options = {
   },
   method: expect.stringMatching(/^GET|POST$/),
 }
-const response = {}
+const response: ServerResponse = { message: 'success' }
 
 it('calls campaigns.trigger.schedule.create()', async () => {
   mockedRequest.mockResolvedValueOnce(response)

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -4,6 +4,7 @@ import * as email from './email'
 import * as messages from './messages'
 import * as sends from './sends'
 import * as subscription from './subscription'
+import * as templates from './templates'
 import * as transactional from './transactional'
 import * as users from './users'
 import * as v2 from './v2'
@@ -124,6 +125,15 @@ export class Braze {
     user: {
       status: (body: subscription.user.SubscriptionUserStatusObject) =>
         subscription.user.status(this.apiUrl, this.apiKey, body),
+    },
+  }
+
+  templates = {
+    content_blocks: {
+      get: (body: templates.content_blocks.ContentBlockBody) =>
+        templates.content_blocks.getContentBlock(this.apiUrl, this.apiKey, body),
+      list: (body: templates.content_blocks.ContentBlockListBody) =>
+        templates.content_blocks.listContentBlocks(this.apiUrl, this.apiKey, body),
     },
   }
 

--- a/src/campaigns/trigger/schedule/create.test.ts
+++ b/src/campaigns/trigger/schedule/create.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { create } from '.'
 import type { CampaignsTriggerScheduleCreateObject } from './types'
 
@@ -82,7 +82,7 @@ describe('/campaigns/trigger/schedule/create', () => {
     },
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/campaigns/trigger/schedule/create.ts
+++ b/src/campaigns/trigger/schedule/create.ts
@@ -1,5 +1,6 @@
 import { post } from '../../../common/request'
 import type { CampaignsTriggerScheduleCreateObject } from './types'
+import { CampaignsTriggerScheduleCreateResponse } from './types'
 
 /**
  * Schedule API-triggered campaigns.
@@ -13,7 +14,11 @@ import type { CampaignsTriggerScheduleCreateObject } from './types'
  * @param body - Request parameters.
  * @returns - Braze response.
  */
-export function create(apiUrl: string, apiKey: string, body: CampaignsTriggerScheduleCreateObject) {
+export function create(
+  apiUrl: string,
+  apiKey: string,
+  body: CampaignsTriggerScheduleCreateObject,
+): Promise<CampaignsTriggerScheduleCreateResponse> {
   const options = {
     headers: {
       'Content-Type': 'application/json',
@@ -21,8 +26,5 @@ export function create(apiUrl: string, apiKey: string, body: CampaignsTriggerSch
     },
   }
 
-  return post(`${apiUrl}/campaigns/trigger/schedule/create`, body, options) as Promise<{
-    dispatch_id: string
-    schedule_id: string
-  }>
+  return post(`${apiUrl}/campaigns/trigger/schedule/create`, body, options)
 }

--- a/src/campaigns/trigger/schedule/delete.test.ts
+++ b/src/campaigns/trigger/schedule/delete.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { _delete } from '.'
 import type { CampaignsTriggerScheduleDeleteObject } from './types'
 
@@ -16,7 +16,7 @@ describe('/campaigns/trigger/schedule/delete', () => {
     campaign_id: 'campaign_identifier',
     schedule_id: 'schedule_identifier',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/campaigns/trigger/schedule/types.ts
+++ b/src/campaigns/trigger/schedule/types.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from '../../../common/request'
 import type { ScheduleObject } from '../../../common/types'
 import type { CampaignsTriggerSendObject } from '../types'
 
@@ -8,6 +9,15 @@ import type { CampaignsTriggerSendObject } from '../types'
  */
 export interface CampaignsTriggerScheduleCreateObject extends CampaignsTriggerSendObject {
   schedule: ScheduleObject
+}
+/**
+ * Response body for schedule API-triggered campaigns.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_campaigns/#request-body}
+ */
+export interface CampaignsTriggerScheduleCreateResponse extends ServerResponse {
+  dispatch_id: string
+  schedule_id: string
 }
 
 /**

--- a/src/campaigns/trigger/schedule/update.test.ts
+++ b/src/campaigns/trigger/schedule/update.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { update } from '.'
 import type { CampaignsTriggerScheduleUpdateObject } from './types'
 
@@ -20,7 +20,7 @@ describe('/campaigns/trigger/schedule/update', () => {
       in_local_time: true,
     },
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/campaigns/trigger/send.test.ts
+++ b/src/campaigns/trigger/send.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { send } from '.'
 import type { CampaignsTriggerSendObject } from './types'
 
@@ -27,7 +27,7 @@ describe('/campaigns/trigger/send', () => {
       },
     ],
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/canvas/trigger/schedule/create.test.ts
+++ b/src/canvas/trigger/schedule/create.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { create } from '.'
 import type { CanvasTriggerScheduleCreateObject } from './types'
 
@@ -80,7 +80,7 @@ describe('/canvas/trigger/schedule/create', () => {
       at_optimal_time: false,
     },
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/canvas/trigger/schedule/create.ts
+++ b/src/canvas/trigger/schedule/create.ts
@@ -1,5 +1,6 @@
 import { post } from '../../../common/request'
 import type { CanvasTriggerScheduleCreateObject } from './types'
+import { CanvasTriggerScheduleCreatResponse } from './types'
 
 /**
  * Schedule API-triggered canvases.
@@ -13,7 +14,11 @@ import type { CanvasTriggerScheduleCreateObject } from './types'
  * @param body - Request parameters.
  * @returns - Braze response.
  */
-export function create(apiUrl: string, apiKey: string, body: CanvasTriggerScheduleCreateObject) {
+export function create(
+  apiUrl: string,
+  apiKey: string,
+  body: CanvasTriggerScheduleCreateObject,
+): Promise<CanvasTriggerScheduleCreatResponse> {
   const options = {
     headers: {
       'Content-Type': 'application/json',
@@ -21,8 +26,5 @@ export function create(apiUrl: string, apiKey: string, body: CanvasTriggerSchedu
     },
   }
 
-  return post(`${apiUrl}/canvas/trigger/schedule/create`, body, options) as Promise<{
-    dispatch_id: string
-    schedule_id: string
-  }>
+  return post(`${apiUrl}/canvas/trigger/schedule/create`, body, options)
 }

--- a/src/canvas/trigger/schedule/delete.test.ts
+++ b/src/canvas/trigger/schedule/delete.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { _delete } from '.'
 import type { CanvasTriggerScheduleDeleteObject } from './types'
 
@@ -16,7 +16,7 @@ describe('/canvas/trigger/schedule/delete', () => {
     canvas_id: 'canvas_identifier',
     schedule_id: 'schedule_identifier',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/canvas/trigger/schedule/types.ts
+++ b/src/canvas/trigger/schedule/types.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from '../../../common/request'
 import type { ScheduleObject } from '../../../common/types'
 import type { CanvasTriggerSendObject } from '../types'
 
@@ -8,6 +9,16 @@ import type { CanvasTriggerSendObject } from '../types'
  */
 export interface CanvasTriggerScheduleCreateObject extends CanvasTriggerSendObject {
   schedule: ScheduleObject
+}
+
+/**
+ * Response body for schedule API-triggered canvases.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/schedule_messages/post_schedule_triggered_canvases/#request-body}
+ */
+export interface CanvasTriggerScheduleCreatResponse extends ServerResponse {
+  dispatch_id: string
+  schedule_id: string
 }
 
 /**

--- a/src/canvas/trigger/schedule/update.test.ts
+++ b/src/canvas/trigger/schedule/update.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { update } from '.'
 import type { CanvasTriggerScheduleUpdateObject } from './types'
 
@@ -20,7 +20,7 @@ describe('/canvas/trigger/schedule/update', () => {
       in_local_time: true,
     },
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/canvas/trigger/send.test.ts
+++ b/src/canvas/trigger/send.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { send } from '.'
 import type { CanvasTriggerSendObject } from './types'
 
@@ -78,7 +78,7 @@ describe('/canvas/trigger/send', () => {
       },
     ],
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/common/request/params.test.ts
+++ b/src/common/request/params.test.ts
@@ -1,0 +1,27 @@
+import { buildParams } from './params'
+
+describe('params', () => {
+  it('should handle string', () => {
+    const params = buildParams({ a: 'string' })
+    expect(params.toString()).toEqual('a=string')
+  })
+
+  it('should handle number', () => {
+    const params = buildParams({ b: 1 })
+    expect(params.toString()).toEqual('b=1')
+  })
+
+  it('should handle boolean', () => {
+    const params = buildParams({ a: true, b: false })
+    expect(params.toString()).toEqual('a=true&b=false')
+  })
+
+  it('should handle undefined', () => {
+    const params = buildParams({ a: undefined })
+    expect(params.toString()).toEqual('')
+  })
+
+  it('should fail on anything else', () => {
+    expect(() => buildParams({ a: [1] })).toThrowError('Unhandled param type for "a"')
+  })
+})

--- a/src/common/request/params.ts
+++ b/src/common/request/params.ts
@@ -1,0 +1,18 @@
+import { URLSearchParams } from 'url'
+
+export function buildParams(body: Record<string, any>): URLSearchParams {
+  return Object.entries(body).reduce((params, [key, value]) => {
+    if (typeof value === 'boolean') {
+      params.append(key, JSON.stringify(value))
+    } else if (typeof value === 'string') {
+      params.append(key, value)
+    } else if (typeof value === 'number') {
+      params.append(key, value.toString())
+    } else if (typeof value === 'undefined') {
+      // Intentionally skip value
+    } else {
+      throw new Error(`Unhandled param type for "${key}"`)
+    }
+    return params
+  }, new URLSearchParams())
+}

--- a/src/common/request/post.test.ts
+++ b/src/common/request/post.test.ts
@@ -1,4 +1,4 @@
-import { post, request, RequestMethod } from '.'
+import { post, request, RequestMethod, ServerResponse } from '.'
 
 jest.mock('./request')
 const mockedRequest = jest.mocked(request)
@@ -6,7 +6,7 @@ const mockedRequest = jest.mocked(request)
 describe('post', () => {
   const url = 'https://example.com/'
   const body = {}
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
   const options = {
     headers: {
       'Content-Type': 'application/json',

--- a/src/common/request/post.ts
+++ b/src/common/request/post.ts
@@ -1,9 +1,11 @@
-import { request, RequestMethod } from './request'
+import { request, RequestMethod, ServerResponse } from './request'
 
 /**
  * Sends a post request.
  */
-export function post(...args: Parameters<typeof request>) {
+export function post<Response extends ServerResponse = ServerResponse>(
+  ...args: Parameters<typeof request>
+) {
   const [url, body, options] = args
-  return request(url, body, { ...options, method: RequestMethod.POST })
+  return request<Response>(url, body, { ...options, method: RequestMethod.POST })
 }

--- a/src/common/request/request.test.ts
+++ b/src/common/request/request.test.ts
@@ -1,7 +1,7 @@
 import type { Response } from 'node-fetch'
 import fetch from 'node-fetch'
 
-import { request, RequestMethod } from '.'
+import { request, RequestMethod, ServerResponse } from '.'
 
 jest.mock('node-fetch')
 const mockedFetch = jest.mocked(fetch)
@@ -9,7 +9,7 @@ const mockedFetch = jest.mocked(fetch)
 describe('request', () => {
   const url = 'https://example.com/'
   const body = {}
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
   const response = {
     json: jest.fn(),
     ok: true,
@@ -19,6 +19,15 @@ describe('request', () => {
     jest.clearAllMocks()
     mockedFetch.mockReturnValueOnce(response as unknown as Promise<Response>)
     response.json.mockResolvedValueOnce(data)
+  })
+
+  it('calls fetch with url', async () => {
+    expect(await request(url)).toBe(data)
+    expect(mockedFetch).toBeCalledWith(url, {
+      body: undefined,
+    })
+    expect(mockedFetch).toBeCalledTimes(1)
+    expect(response.json).toBeCalledTimes(1)
   })
 
   it('calls fetch with url and body', async () => {

--- a/src/common/request/request.ts
+++ b/src/common/request/request.ts
@@ -6,19 +6,12 @@ export enum RequestMethod {
   POST = 'POST',
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type RequestBody = Record<string, any>
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type ResponseBody = Record<string, any>
-
 /**
  * {@link https://www.braze.com/docs/api/errors/#server-responses}
  */
-interface ServerResponse {
+export interface ServerResponse {
   message: string
   errors?: string[]
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  [key: string]: any
 }
 
 class ResponseError extends Error {
@@ -40,17 +33,17 @@ class ResponseError extends Error {
  * @param options - Request options.
  * @returns - Response.
  */
-export async function request(
+export async function request<Response extends ServerResponse = ServerResponse>(
   url: string,
-  body: RequestBody,
+  body?: Record<string, any>,
   options?: RequestInit,
-): Promise<ResponseBody> {
+): Promise<Response> {
   const response = await fetch(url, {
-    body: JSON.stringify(body),
+    body: body ? JSON.stringify(body) : undefined,
     ...options,
   })
 
-  const data: ServerResponse = await response.json()
+  const data: Response = await response.json()
 
   if (response.ok) {
     return data

--- a/src/email/blacklist.test.ts
+++ b/src/email/blacklist.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../common/request'
+import { post, ServerResponse } from '../common/request'
 import { blacklist } from '.'
 import type { EmailBlacklistObject } from './types'
 
@@ -15,7 +15,7 @@ describe('/email/blacklist', () => {
   const body: EmailBlacklistObject = {
     email: ['blacklist_email1', 'blacklist_email2'],
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/email/bounce/remove.test.ts
+++ b/src/email/bounce/remove.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { remove } from '.'
 import type { EmailBounceRemoveObject } from './types'
 
@@ -15,7 +15,7 @@ describe('/email/bounce/remove', () => {
   const body: EmailBounceRemoveObject = {
     email: 'example@braze.com',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/email/spam/remove.test.ts
+++ b/src/email/spam/remove.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { remove } from '.'
 import type { EmailSpamRemoveObject } from './types'
 
@@ -15,7 +15,7 @@ describe('/email/spam/remove', () => {
   const body: EmailSpamRemoveObject = {
     email: 'example@braze.com',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/messages/schedule/create.test.ts
+++ b/src/messages/schedule/create.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { create } from '.'
 import type { MessagesScheduleCreateObject } from './types'
 
@@ -82,7 +82,7 @@ describe('/messages/schedule/create', () => {
     messages: {},
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/messages/schedule/delete.test.ts
+++ b/src/messages/schedule/delete.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { _delete } from '.'
 import type { MessagesScheduleDeleteObject } from './types'
 
@@ -15,7 +15,7 @@ describe('/messages/schedule/delete', () => {
   const body: MessagesScheduleDeleteObject = {
     schedule_id: 'schedule_identifier',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/messages/schedule/update.test.ts
+++ b/src/messages/schedule/update.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { update } from '.'
 import type { MessagesScheduleUpdateObject } from './types'
 
@@ -36,7 +36,7 @@ describe('/messages/schedule/update', () => {
     },
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/messages/scheduled_broadcasts.test.ts
+++ b/src/messages/scheduled_broadcasts.test.ts
@@ -1,4 +1,4 @@
-import { get } from '../common/request'
+import { get, ServerResponse } from '../common/request'
 import { scheduled_broadcasts } from '.'
 
 jest.mock('../common/request')
@@ -14,7 +14,7 @@ describe('/messages/scheduled_broadcasts', () => {
   const body = {
     end_time: '2018-09-01T00:00:00-04:00',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)

--- a/src/messages/scheduled_broadcasts.ts
+++ b/src/messages/scheduled_broadcasts.ts
@@ -1,4 +1,6 @@
 import { get } from '../common/request'
+import { buildParams } from '../common/request/params'
+import { ScheduledBroadcastsObject, ScheduledBroadcastsResponse } from './types'
 
 /**
  * Get upcoming scheduled campaigns and Canvases.
@@ -12,7 +14,11 @@ import { get } from '../common/request'
  * @param body - Request parameters.
  * @returns - Braze response.
  */
-export function scheduled_broadcasts(apiUrl: string, apiKey: string, body: { end_time: string }) {
+export function scheduled_broadcasts(
+  apiUrl: string,
+  apiKey: string,
+  body: ScheduledBroadcastsObject,
+): Promise<ScheduledBroadcastsResponse> {
   const options = {
     headers: {
       'Content-Type': 'application/json',
@@ -20,18 +26,5 @@ export function scheduled_broadcasts(apiUrl: string, apiKey: string, body: { end
     },
   }
 
-  return get(
-    `${apiUrl}/messages/scheduled_broadcasts?${new URLSearchParams(body)}`,
-    {},
-    options,
-  ) as Promise<{
-    scheduled_broadcasts: {
-      name: string
-      id: string
-      type: 'Canvas' | 'Campaign'
-      tags: string[]
-      next_send_time: string
-      schedule_type: 'local_time_zones' | 'intelligent_delivery' | string
-    }[]
-  }>
+  return get(`${apiUrl}/messages/scheduled_broadcasts?${buildParams(body)}`, {}, options)
 }

--- a/src/messages/send.test.ts
+++ b/src/messages/send.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../common/request'
+import { post, ServerResponse } from '../common/request'
 import { send } from '.'
 import type { MessagesSendObject } from './types'
 
@@ -22,7 +22,7 @@ describe('/messages/send', () => {
       },
     },
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/messages/types.ts
+++ b/src/messages/types.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from '../common/request'
 import type { ConnectedAudienceObject, UserAlias } from '../common/types'
 
 /**
@@ -63,4 +64,19 @@ interface EmailObjectWithBody extends EmailObject {
 
 interface EmailObjectWithEmailTemplateId extends EmailObject {
   email_template_id: string
+}
+
+export interface ScheduledBroadcastsObject {
+  end_time: string
+}
+
+export interface ScheduledBroadcastsResponse extends ServerResponse {
+  scheduled_broadcasts: {
+    name: string
+    id: string
+    type: 'Canvas' | 'Campaign'
+    tags: string[]
+    next_send_time: string
+    schedule_type: 'local_time_zones' | 'intelligent_delivery' | string
+  }[]
 }

--- a/src/sends/id/create.test.ts
+++ b/src/sends/id/create.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { create } from '.'
 import type { SendsIdCreateObject } from './types'
 
@@ -16,7 +16,7 @@ describe('/sends/id/create', () => {
     campaign_id: 'campaign_identifier',
     send_id: 'send_identifier',
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/subscription/status/get.test.ts
+++ b/src/subscription/status/get.test.ts
@@ -1,4 +1,4 @@
-import { get as _get } from '../../common/request'
+import { get as _get, ServerResponse } from '../../common/request'
 import { get } from '.'
 import type { SubscriptionStatusGetObject } from './types'
 
@@ -12,7 +12,7 @@ beforeEach(() => {
 describe('/subscription/status/get', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request for multiple users with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)

--- a/src/subscription/status/set.test.ts
+++ b/src/subscription/status/set.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { set } from '.'
 import type { SubscriptionStatusSetObject } from './types'
 
@@ -12,7 +12,7 @@ beforeEach(() => {
 describe('/subscription/status/set', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request for email with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/subscription/user/status.test.ts
+++ b/src/subscription/user/status.test.ts
@@ -1,4 +1,4 @@
-import { get } from '../../common/request'
+import { get, ServerResponse } from '../../common/request'
 import { status } from '.'
 import type { SubscriptionUserStatusObject } from './types'
 
@@ -12,7 +12,7 @@ beforeEach(() => {
 describe('/subscription/user/status', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request for multiple users with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)

--- a/src/templates/content-blocks/content_blocks.test.ts
+++ b/src/templates/content-blocks/content_blocks.test.ts
@@ -1,0 +1,46 @@
+import { Braze } from '../../Braze'
+import { request, ServerResponse } from '../../common/request'
+
+jest.mock('../../common/request/request')
+const mockedRequest = jest.mocked(request)
+
+const apiUrl = 'https://rest.iad-01.braze.com'
+const apiKey = 'apiKey'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('Content Blocks', () => {
+  const braze = new Braze(apiUrl, apiKey)
+  const options = {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
+  const response: ServerResponse = { message: 'success' }
+
+  it('calls templates.content_blocks.get()', async () => {
+    mockedRequest.mockResolvedValueOnce(response)
+    const contentBlockId = 'YOUR_CONTENT_BLOCK_ID'
+    expect(
+      await braze.templates.content_blocks.get({
+        content_block_id: contentBlockId,
+      }),
+    ).toBe(response)
+    expect(mockedRequest).toBeCalledWith(
+      `${apiUrl}/content_blocks/info?content_block_id=${contentBlockId}`,
+      undefined,
+      options,
+    )
+    expect(mockedRequest).toBeCalledTimes(1)
+  })
+
+  it('calls templates.content_blocks.list()', async () => {
+    mockedRequest.mockResolvedValueOnce(response)
+    expect(await braze.templates.content_blocks.list({})).toBe(response)
+    expect(mockedRequest).toBeCalledWith(`${apiUrl}/content_blocks/list?`, undefined, options)
+    expect(mockedRequest).toBeCalledTimes(1)
+  })
+})

--- a/src/templates/content-blocks/get.ts
+++ b/src/templates/content-blocks/get.ts
@@ -1,0 +1,23 @@
+import { get } from '../../common/request'
+import { buildParams } from '../../common/request/params'
+import { ContentBlockBody, ContentBlockResponse } from './types'
+
+/**
+ * Request content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_see_email_content_blocks_information/}
+ */
+export function getContentBlock(
+  apiUrl: string,
+  apiKey: string,
+  body: ContentBlockBody,
+): Promise<ContentBlockResponse> {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return get(`${apiUrl}/content_blocks/info?${buildParams(body)}`, undefined, options)
+}

--- a/src/templates/content-blocks/index.ts
+++ b/src/templates/content-blocks/index.ts
@@ -1,0 +1,3 @@
+export * from './get'
+export * from './list'
+export * from './types'

--- a/src/templates/content-blocks/list.ts
+++ b/src/templates/content-blocks/list.ts
@@ -1,0 +1,23 @@
+import { get } from '../../common/request'
+import { buildParams } from '../../common/request/params'
+import { ContentBlockListBody, ContentBlockListResponse } from './types'
+
+/**
+ * Request content block list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_list_email_content_blocks/}
+ */
+export function listContentBlocks(
+  apiUrl: string,
+  apiKey: string,
+  body: ContentBlockListBody,
+): Promise<ContentBlockListResponse> {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return get(`${apiUrl}/content_blocks/list?${buildParams(body)}`, undefined, options)
+}

--- a/src/templates/content-blocks/types.ts
+++ b/src/templates/content-blocks/types.ts
@@ -1,0 +1,60 @@
+import { ServerResponse } from '../../common/request'
+
+/**
+ * Request body for content block list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_list_email_content_blocks/}
+ */
+export interface ContentBlockListBody {
+  modified_after?: string
+  modified_before?: string
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Response body for content block list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_list_email_content_blocks/}
+ */
+export interface ContentBlockListResponse extends ServerResponse {
+  count: number
+  content_blocks: {
+    content_block_id: string
+    name: string
+    content_type: string
+    liquid_tag: string
+    inclusion_count: number
+    created_at: string
+    last_edited: string
+    tags: string[]
+  }[]
+}
+
+/**
+ * Request body for content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_see_email_content_blocks_information/}
+ */
+export interface ContentBlockBody {
+  content_block_id: string
+  include_inclusion_data?: boolean
+}
+
+/**
+ * Response body for content block.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/content_blocks_templates/get_see_email_content_blocks_information/}
+ */
+export interface ContentBlockResponse extends ServerResponse {
+  content_block_id: string
+  name: string
+  content: string
+  description: string
+  content_type: string
+  tags: string[]
+  created_at: string
+  last_edited: string
+  inclusion_count: number
+  inclusion_data: string[]
+}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,0 +1,1 @@
+export * as content_blocks from './content-blocks'

--- a/src/transactional/v1/campaigns/send.test.ts
+++ b/src/transactional/v1/campaigns/send.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { send } from '.'
 import type { TransactionalV1CampaignsSendObject } from './types'
 
@@ -25,7 +25,7 @@ describe('/transactional/v1/campaigns/YOUR_CAMPAIGN_ID_HERE/send', () => {
       },
     ],
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/transactional/v1/campaigns/send.ts
+++ b/src/transactional/v1/campaigns/send.ts
@@ -1,28 +1,5 @@
 import { post } from '../../../common/request'
-import type { TransactionalV1CampaignsSendObject } from './types'
-
-/**
- * Postback body for sending transactional email via API-triggered delivery.
- *
- * {@link https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_transactional_message/#postback-body}
- */
-type Response = {
-  dispatch_id: string
-  status: 'sent' | 'processed' | 'aborted' | 'delivered' | 'bounced'
-  metadata: {
-    external_send_id: string
-    campaign_api_id: string
-    received_at?: string
-    enqueued_at?: string
-    executed_at?: string
-    sent_at?: string
-    processed_at?: string
-    delivered_at?: string
-    bounced_at?: string
-    aborted_at?: string
-    reason?: string
-  }
-}
+import type { CampaignSendResponse, TransactionalV1CampaignsSendObject } from './types'
 
 /**
  * Sending transactional email via API-triggered delivery.
@@ -42,7 +19,7 @@ export function send(
   apiKey: string,
   campaignId: string,
   body: TransactionalV1CampaignsSendObject,
-) {
+): Promise<CampaignSendResponse> {
   const options = {
     headers: {
       'Content-Type': 'application/json',
@@ -50,9 +27,5 @@ export function send(
     },
   }
 
-  return post(
-    `${apiUrl}/transactional/v1/campaigns/${campaignId}/send`,
-    body,
-    options,
-  ) as Promise<Response>
+  return post(`${apiUrl}/transactional/v1/campaigns/${campaignId}/send`, body, options)
 }

--- a/src/transactional/v1/campaigns/types.ts
+++ b/src/transactional/v1/campaigns/types.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from '../../../common/request'
 import type { Attributes, TriggerProperties, UserAlias } from '../../../common/types'
 
 /**
@@ -19,4 +20,27 @@ interface RecipientWithExternalUserId {
 interface RecipientWithUserAlias {
   user_alias: UserAlias
   attributes?: Attributes
+}
+
+/**
+ * Postback body for sending transactional email via API-triggered delivery.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/messaging/send_messages/post_send_transactional_message/#postback-body}
+ */
+export interface CampaignSendResponse extends ServerResponse {
+  dispatch_id: string
+  status: 'sent' | 'processed' | 'aborted' | 'delivered' | 'bounced'
+  metadata: {
+    external_send_id: string
+    campaign_api_id: string
+    received_at?: string
+    enqueued_at?: string
+    executed_at?: string
+    sent_at?: string
+    processed_at?: string
+    delivered_at?: string
+    bounced_at?: string
+    aborted_at?: string
+    reason?: string
+  }
 }

--- a/src/users/alias/new.test.ts
+++ b/src/users/alias/new.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import type { UsersAliasObject } from '.'
 import { _new } from '.'
 
@@ -22,7 +22,7 @@ describe('/users/alias/new', () => {
     ],
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/users/delete.test.ts
+++ b/src/users/delete.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../common/request'
+import { post, ServerResponse } from '../common/request'
 import { _delete } from '.'
 import type { UsersDeleteObject } from './types'
 
@@ -27,7 +27,7 @@ describe('/users/delete', () => {
     ],
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/users/delete.ts
+++ b/src/users/delete.ts
@@ -1,5 +1,6 @@
 import { post } from '../common/request'
 import type { UsersDeleteObject } from './types'
+import { UsersDeleteResponse } from './types'
 
 /**
  * User delete endpoint.
@@ -13,7 +14,11 @@ import type { UsersDeleteObject } from './types'
  * @param body - Request parameters.
  * @returns - Braze response.
  */
-export function _delete(apiUrl: string, apiKey: string, body: UsersDeleteObject) {
+export function _delete(
+  apiUrl: string,
+  apiKey: string,
+  body: UsersDeleteObject,
+): Promise<UsersDeleteResponse> {
   const options = {
     headers: {
       'Content-Type': 'application/json',
@@ -21,7 +26,5 @@ export function _delete(apiUrl: string, apiKey: string, body: UsersDeleteObject)
     },
   }
 
-  return post(`${apiUrl}/users/delete`, body, options) as Promise<{
-    deleted: number
-  }>
+  return post(`${apiUrl}/users/delete`, body, options)
 }

--- a/src/users/external_ids/remove.test.ts
+++ b/src/users/external_ids/remove.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { remove } from '.'
 import type { UsersExternalIdsRemoveObject } from './types'
 
@@ -15,7 +15,7 @@ describe('/users/external_ids/remove', () => {
   const body: UsersExternalIdsRemoveObject = {
     external_ids: ['existing_deprecated_external_id_string'],
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/users/external_ids/rename.test.ts
+++ b/src/users/external_ids/rename.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../common/request'
+import { post, ServerResponse } from '../../common/request'
 import { rename } from '.'
 import type { UsersExternalIdsRenameObject } from './types'
 
@@ -20,7 +20,7 @@ describe('/users/external_ids/rename', () => {
       },
     ],
   }
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/users/identify.test.ts
+++ b/src/users/identify.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../common/request'
+import { post, ServerResponse } from '../common/request'
 import { identify } from '.'
 import type { UsersIdentifyObject } from './types'
 
@@ -24,7 +24,7 @@ describe('/users/identify', () => {
     ],
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/users/track.test.ts
+++ b/src/users/track.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../common/request'
+import { post, ServerResponse } from '../common/request'
 import { track } from '.'
 import type { UsersTrackObject } from './types'
 
@@ -48,7 +48,7 @@ describe('/users/track', () => {
     ],
   }
 
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)

--- a/src/users/types.ts
+++ b/src/users/types.ts
@@ -1,3 +1,4 @@
+import { ServerResponse } from '../common/request'
 import type { Properties, UserAlias } from '../common/types'
 
 /**
@@ -32,6 +33,15 @@ export interface UsersDeleteObject {
   external_ids?: string[]
   user_aliases?: UserAlias[]
   braze_ids?: string[]
+}
+
+/**
+ * Response body for user delete.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/user_data/post_user_delete/#request-body}
+ */
+export interface UsersDeleteResponse extends ServerResponse {
+  deleted: number
 }
 
 /**

--- a/src/v2/subscription/status/set.test.ts
+++ b/src/v2/subscription/status/set.test.ts
@@ -1,4 +1,4 @@
-import { post } from '../../../common/request'
+import { post, ServerResponse } from '../../../common/request'
 import { set } from '.'
 import type { V2SubscriptionStatusSetObject } from './types'
 
@@ -12,7 +12,7 @@ beforeEach(() => {
 describe('/v2/subscription/status/set', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
-  const data = {}
+  const data: ServerResponse = { message: 'success' }
 
   it('calls request for email and SMS with url and body', async () => {
     mockedPost.mockResolvedValueOnce(data)


### PR DESCRIPTION
And refactor some code for simplification

<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

My company has started utilizing braze and I was looking for a node cli to make requests. In playing with your code I found that it didn't have content blocks functionality so I was trying to see if this could work. So I played with the code and found it to be rather easy to add new code.

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?

Does not have access to the content blocks

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?

I started adding content block functionality for list and get which is what I need initially.

In doing so I refactored some code to be a little more robust for typescript support. I might be overstepping with what I've done but I'm suggesting it with experience. Feel free to push back. I'm really looking to ask what kind of additions you'd be looking for in a pull request? Have I gone too far and would you only like simple additions of new endpoints?

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->