### PR TITLE
fix(catalog items): add pagination

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,6 @@
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-simple-import-sort": "10.0.0",
         "eslint-plugin-tsdoc": "0.2.17",
-        "fetch-mock": "9.11.0",
         "fetch-mock-jest": "1.5.1",
         "husky": "8.0.3",
         "jest": "29.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-simple-import-sort": "10.0.0",
         "eslint-plugin-tsdoc": "0.2.17",
+        "fetch-mock": "9.11.0",
+        "fetch-mock-jest": "1.5.1",
         "husky": "8.0.3",
         "jest": "29.5.0",
         "lint-staged": "13.2.0",
@@ -583,6 +585,18 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "dev": true,
+      "dependencies": {
+        "regenerator-runtime": "^0.13.11"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -2571,6 +2585,17 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/core-js": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
@@ -3208,6 +3233,89 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock-jest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
+      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "dev": true,
+      "dependencies": {
+        "fetch-mock": "^9.11.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "funding": {
+        "type": "charity",
+        "url": "https://www.justgiving.com/refugee-support-europe"
+      },
+      "peerDependencies": {
+        "node-fetch": "*"
+      },
+      "peerDependenciesMeta": {
+        "node-fetch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fetch-mock/node_modules/tr46": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+      "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/fetch-mock/node_modules/webidl-conversions": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+      "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+      "dev": true
+    },
+    "node_modules/fetch-mock/node_modules/whatwg-url": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.sortby": "^4.7.0",
+        "tr46": "^1.0.1",
+        "webidl-conversions": "^4.0.2"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3409,6 +3517,12 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "node_modules/global-dirs": {
       "version": "0.1.1",
@@ -3759,6 +3873,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
+      "dev": true
     },
     "node_modules/is-text-path": {
       "version": "1.0.1",
@@ -4867,6 +4987,12 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
     "node_modules/lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -4907,6 +5033,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
     "node_modules/lodash.startcase": {
@@ -5472,6 +5604,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -5707,6 +5845,16 @@
         "teleport": ">=0.2.0"
       }
     },
+    "node_modules/querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "deprecated": "The querystring API is considered Legacy. new code should use the URLSearchParams API instead.",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.x"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -5897,6 +6045,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
     },
     "node_modules/require-directory": {
       "version": "2.1.1",
@@ -7453,6 +7607,15 @@
         "@babel/helper-plugin-utils": "^7.19.0"
       }
     },
+    "@babel/runtime": {
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.21.0.tgz",
+      "integrity": "sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==",
+      "dev": true,
+      "requires": {
+        "regenerator-runtime": "^0.13.11"
+      }
+    },
     "@babel/template": {
       "version": "7.20.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.20.7.tgz",
@@ -8979,6 +9142,12 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "core-js": {
+      "version": "3.29.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.29.1.tgz",
+      "integrity": "sha512-+jwgnhg6cQxKYIIjGtAHq2nwUOolo9eoFZ4sHfUH09BLXBgxnH4gA0zEd+t+BO2cNB8idaBtZFcFTRjQJRJmAw==",
+      "dev": true
+    },
     "cosmiconfig": {
       "version": "8.1.3",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-8.1.3.tgz",
@@ -9458,6 +9627,61 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-mock": {
+      "version": "9.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-mock/-/fetch-mock-9.11.0.tgz",
+      "integrity": "sha512-PG1XUv+x7iag5p/iNHD4/jdpxL9FtVSqRMUQhPab4hVDt80T1MH5ehzVrL2IdXO9Q2iBggArFvPqjUbHFuI58Q==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "^7.0.0",
+        "@babel/runtime": "^7.0.0",
+        "core-js": "^3.0.0",
+        "debug": "^4.1.1",
+        "glob-to-regexp": "^0.4.0",
+        "is-subset": "^0.1.1",
+        "lodash.isequal": "^4.5.0",
+        "path-to-regexp": "^2.2.1",
+        "querystring": "^0.2.0",
+        "whatwg-url": "^6.5.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-1.0.1.tgz",
+          "integrity": "sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==",
+          "dev": true,
+          "requires": {
+            "punycode": "^2.1.0"
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
+          "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==",
+          "dev": true
+        },
+        "whatwg-url": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+          "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
+          "dev": true,
+          "requires": {
+            "lodash.sortby": "^4.7.0",
+            "tr46": "^1.0.1",
+            "webidl-conversions": "^4.0.2"
+          }
+        }
+      }
+    },
+    "fetch-mock-jest": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/fetch-mock-jest/-/fetch-mock-jest-1.5.1.tgz",
+      "integrity": "sha512-+utwzP8C+Pax1GSka3nFXILWMY3Er2L+s090FOgqVNrNCPp0fDqgXnAHAJf12PLHi0z4PhcTaZNTz8e7K3fjqQ==",
+      "dev": true,
+      "requires": {
+        "fetch-mock": "^9.11.0"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9601,6 +9825,12 @@
       "requires": {
         "is-glob": "^4.0.3"
       }
+    },
+    "glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "dev": true
     },
     "global-dirs": {
       "version": "0.1.1",
@@ -9849,6 +10079,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha512-6Ybun0IkarhmEqxXCNw/C0bna6Zb/TkfUX9UbwJtK6ObwAVCxmAP308WWTHviM/zAqXk05cdhYsUsZeGQh99iw==",
       "dev": true
     },
     "is-text-path": {
@@ -10673,6 +10909,12 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "dev": true
+    },
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
@@ -10713,6 +10955,12 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
+      "dev": true
+    },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
       "dev": true
     },
     "lodash.startcase": {
@@ -11132,6 +11380,12 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
+      "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
+      "dev": true
+    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -11284,6 +11538,12 @@
       "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==",
       "dev": true
     },
+    "querystring": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.1.tgz",
+      "integrity": "sha512-wkvS7mL/JMugcup3/rMitHmd9ecIGd2lhFhK9N3UUQ450h66d1r3Y9nvXzQAW1Lq+wyx61k/1pfKS5KuKiyEbg==",
+      "dev": true
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11422,6 +11682,12 @@
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
       }
+    },
+    "regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==",
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,8 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "10.0.0",
     "eslint-plugin-tsdoc": "0.2.17",
+    "fetch-mock": "9.11.0",
+    "fetch-mock-jest": "1.5.1",
     "husky": "8.0.3",
     "jest": "29.5.0",
     "lint-staged": "13.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-simple-import-sort": "10.0.0",
     "eslint-plugin-tsdoc": "0.2.17",
-    "fetch-mock": "9.11.0",
     "fetch-mock-jest": "1.5.1",
     "husky": "8.0.3",
     "jest": "29.5.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "docs:watch": "npm run docs -- --watch",
     "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
     "lint:fix": "npm run lint -- --fix",
-    "lint:tsc": "tsc",
+    "lint:tsc": "tsc && tsc --project tsconfig.test.json",
     "postinstall": "husky install",
     "postpublish": "pinst --enable",
     "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm run test:ci && npm run clean && npm run build",

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -14,12 +14,12 @@ export class Braze {
   /**
    * {@link https://www.braze.com/docs/api/basics/#endpoints}
    */
-  private apiUrl: string
+  private readonly apiUrl: string
 
   /**
    * {@link https://www.braze.com/docs/api/basics/#app-group-rest-api-keys}
    */
-  private apiKey: string
+  private readonly apiKey: string
 
   /**
    * @param apiUrl - Braze REST endpoint.

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -79,7 +79,7 @@ export class Braze {
       list: () => catalogs.synchronous.listCatalogs(this.apiUrl, this.apiKey),
       items: <T extends catalogs.synchronous.CatalogListItem>(
         body: catalogs.synchronous.CatalogListItemsBody,
-      ) => catalogs.synchronous.listCatalogItems<T>(this.apiUrl, this.apiKey, body),
+      ) => catalogs.synchronous.getListCatalogItemsIterator<T>(this.apiUrl, this.apiKey, body),
       item: <T extends catalogs.synchronous.CatalogListItem>(
         body: catalogs.synchronous.CatalogListItemBody,
       ) => catalogs.synchronous.getCatalogItem<T>(this.apiUrl, this.apiKey, body),

--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -14,12 +14,12 @@ export class Braze {
   /**
    * {@link https://www.braze.com/docs/api/basics/#endpoints}
    */
-  private readonly apiUrl: string
+  private apiUrl: string
 
   /**
    * {@link https://www.braze.com/docs/api/basics/#app-group-rest-api-keys}
    */
-  private readonly apiKey: string
+  private apiKey: string
 
   /**
    * @param apiUrl - Braze REST endpoint.

--- a/src/catalogs/synchronous/catalogs.test.ts
+++ b/src/catalogs/synchronous/catalogs.test.ts
@@ -11,13 +11,10 @@ import {
   CatalogListResponse,
 } from './types'
 
-jest.mock('../../common/request/request', () => {
-  const originalRequest = jest.requireActual('../../common/request/request')
-  return {
-    ...originalRequest,
-    request: jest.fn(),
-  }
-})
+jest.mock('../../common/request/request', () => ({
+  ...jest.requireActual('../../common/request/request'),
+  request: jest.fn(),
+}))
 const mockedRequest = jest.mocked(request)
 jest.mock('node-fetch', () => fetchMockJest.sandbox())
 const fetchMock = fetch as unknown as FetchMockStatic

--- a/src/catalogs/synchronous/catalogs.test.ts
+++ b/src/catalogs/synchronous/catalogs.test.ts
@@ -1,4 +1,3 @@
-import { FetchMockStatic } from 'fetch-mock'
 import * as fetchMockJest from 'fetch-mock-jest'
 import fetch from 'node-fetch'
 
@@ -17,7 +16,7 @@ jest.mock('../../common/request/request', () => ({
 }))
 const mockedRequest = jest.mocked(request)
 jest.mock('node-fetch', () => fetchMockJest.sandbox())
-const fetchMock = fetch as unknown as FetchMockStatic
+const fetchMock = fetch as unknown as typeof fetchMockJest
 
 const apiUrl = 'https://rest.iad-01.braze.com'
 const apiKey = 'apiKey'
@@ -48,7 +47,9 @@ describe('Catalogs - Synchronous', () => {
   })
 
   describe('List Catalog Items', () => {
-    beforeEach(() => fetchMock.reset())
+    beforeEach(() => {
+      fetchMock.reset()
+    })
 
     type ResponseType = CatalogListItem<{ foo: string }>
     const response: CatalogListItemsResponse<ResponseType> = {

--- a/src/catalogs/synchronous/list_items.ts
+++ b/src/catalogs/synchronous/list_items.ts
@@ -1,24 +1,59 @@
-import { get } from '../../common/request'
-import { buildParams } from '../../common/request/params'
+import fetch, { Response } from 'node-fetch'
+
+import { ResponseError } from '../../common/request'
 import { CatalogListItem, CatalogListItemsBody, CatalogListItemsResponse } from './types'
+
+function getNextPageLink(linkHeader: string | null): string | undefined {
+  const linkMatches = linkHeader?.matchAll(/<([^>]+)>; rel="(prev|next)"/g)
+  if (linkMatches) {
+    for (const match of linkMatches) {
+      if (match[2] === 'next') {
+        return match[1]
+      }
+    }
+  }
+}
 
 /**
  * Request catalog items.
  *
  * {@link https://www.braze.com/docs/api/endpoints/catalogs/catalog_items/synchronous/get_catalog_items_details_bulk/}
  */
-export function listCatalogItems<T extends CatalogListItem>(
+export async function listCatalogItems<T extends CatalogListItem>(
   apiUrl: string,
   apiKey: string,
-  body: CatalogListItemsBody,
+  { catalog_name, max_pages }: CatalogListItemsBody,
 ): Promise<CatalogListItemsResponse<T>> {
-  const options = {
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${apiKey}`,
-    },
-  }
-  const { catalog_name, ...params } = body
+  let uri: string | undefined = `/catalogs/${catalog_name}/items`
+  let data: CatalogListItemsResponse<T> | undefined
+  let total_requests = 0
 
-  return get(`${apiUrl}/catalogs/${catalog_name}/items?${buildParams(params)}`, undefined, options)
+  do {
+    total_requests++
+    const response: Response = await fetch(apiUrl + uri, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+    })
+    const jsonResponse = await response.json()
+
+    if (response.ok) {
+      if (!data) {
+        data = jsonResponse
+      } else {
+        data.items = data.items.concat(jsonResponse.items)
+      }
+    } else {
+      throw new ResponseError(jsonResponse.message, response.status, jsonResponse.errors)
+    }
+
+    if (max_pages && total_requests >= max_pages) {
+      break
+    }
+
+    uri = getNextPageLink(response.headers.get('Link'))
+  } while (uri)
+
+  return data as CatalogListItemsResponse<T>
 }

--- a/src/catalogs/synchronous/types.ts
+++ b/src/catalogs/synchronous/types.ts
@@ -22,7 +22,7 @@ export interface CatalogListResponse extends ServerResponse {
  */
 export interface CatalogListItemsBody {
   catalog_name: string
-  cursor?: string
+  max_pages?: number
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/common/request/request.ts
+++ b/src/common/request/request.ts
@@ -15,13 +15,13 @@ export interface ServerResponse {
 }
 
 export class ResponseError extends Error {
-  public readonly name = 'ResponseError'
-  constructor(
-    message: string,
-    public readonly status: number,
-    public readonly errors?: ServerResponse['errors'],
-  ) {
+  status: number
+  errors?: ServerResponse['errors']
+
+  constructor(message: string, status: number, errors?: ServerResponse['errors']) {
     super(message)
+    this.status = status
+    this.errors = errors
   }
 }
 

--- a/src/common/request/request.ts
+++ b/src/common/request/request.ts
@@ -14,14 +14,14 @@ export interface ServerResponse {
   errors?: string[]
 }
 
-class ResponseError extends Error {
-  status: number
-  errors?: ServerResponse['errors']
-
-  constructor(message: string, status: number, errors?: ServerResponse['errors']) {
+export class ResponseError extends Error {
+  public readonly name = 'ResponseError'
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly errors?: ServerResponse['errors'],
+  ) {
     super(message)
-    this.status = status
-    this.errors = errors
   }
 }
 

--- a/src/templates/content-blocks/content_blocks.test.ts
+++ b/src/templates/content-blocks/content_blocks.test.ts
@@ -71,7 +71,11 @@ describe('Content Blocks', () => {
   })
 
   describe('templates.content_blocks.list()', () => {
-    const response: ContentBlockListResponse = { content_blocks: [], count: 0, message: 'success' }
+    const response: ContentBlockListResponse = {
+      content_blocks: [],
+      count: 0,
+      message: 'success',
+    }
 
     it('is called with required params', async () => {
       mockedRequest.mockResolvedValueOnce(response)

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false
+    "noEmit": false,
+    "lib": ["es2020"]
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "noEmit": false,
-    "lib": ["es2020"]
+    "noEmit": false
   },
   "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2020"],
+    "lib": ["es2020", "dom"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2020",
     "module": "commonjs",
-    "lib": ["es2020", "dom"],
+    "lib": ["es2020"],
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
@@ -11,5 +11,6 @@
     "outDir": "lib",
     "noEmit": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "lib": ["es2020", "dom"]
   },
   "include": ["**/*.test.ts"],
-  "exclude": ["node_modules"]
+  "exclude": []
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "lib": ["es2020", "dom"]
+  },
+  "include": ["**/*.test.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
The catalog items only returns 50 items per page. In order to return all items we have to reference the `Link` header to see if there’s a next page

<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
Pagination wasn't working for catalog list items so adding functionality to make it work.

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
catalog list items will only return the first page of results (up to 50)

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?
The function will loop through all available results and return the object. Note: this is not efficient for extremely large result sets. Down the line it might be good to add streaming of results if desired.

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
