### PR TITLE
feat(catalog list items): return generator instead of array

### DIFF
--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -79,7 +79,7 @@ export class Braze {
       list: () => catalogs.synchronous.listCatalogs(this.apiUrl, this.apiKey),
       items: <T extends catalogs.synchronous.CatalogListItem>(
         body: catalogs.synchronous.CatalogListItemsBody,
-      ) => catalogs.synchronous.listCatalogItems<T>(this.apiUrl, this.apiKey, body),
+      ) => catalogs.synchronous.getListCatalogItemsIterator<T>(this.apiUrl, this.apiKey, body),
       item: <T extends catalogs.synchronous.CatalogListItem>(
         body: catalogs.synchronous.CatalogListItemBody,
       ) => catalogs.synchronous.getCatalogItem<T>(this.apiUrl, this.apiKey, body),


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?
The list item categories hides way items is retrieved. This new way will give the user more control if they want it.

<!-- Is this a feature, bug fix, documentation, etc.? -->

## What is the current behavior?
The function returns an array of items which with large result sets could result in a lot of memory usage and delays before processing begins

<!-- Please link to the issue (if applicable). -->

## What is the new behavior?
The `catalogs.synchronous.items` now returns a generator that can be looped over and will only fetch the next set of data when iterating over the first set is complete

<!-- If this is a feature change or bug fix. -->

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
