### PR TITLE
fix: correct typing of users track returned errors

### DIFF
--- a/src/users/track.ts
+++ b/src/users/track.ts
@@ -31,6 +31,6 @@ export function track(apiUrl: string, apiKey: string, body: UsersTrackObject, bu
     attributes_processed?: number
     events_processed?: number
     purchases_processed?: number
-    errors?: object
+    errors?: object[]
   }>
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix incorrect typing as raised here: https://github.com/remarkablemark/braze-api/issues/206

## What is the current behaviour?

errors is typed as an object

## What is the new behaviour?

Errors is typed as an array of objects

## Checklist:


- [x] [Conventional Commits](https://www.conventionalcommits.org/)

