### PR TITLE
fix: subscription.status.get pass undefined body instead of empty object

### DIFF
--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -217,7 +217,7 @@ it('calls subscription.status.get()', async () => {
   expect(await braze.subscription.status.get(body)).toBe(response)
   expect(mockedRequest).toBeCalledWith(
     `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id`,
-    {},
+    undefined,
     { headers: options.headers },
   )
   expect(mockedRequest).toBeCalledTimes(1)

--- a/src/subscription/status/get.test.ts
+++ b/src/subscription/status/get.test.ts
@@ -23,7 +23,7 @@ describe('/subscription/status/get', () => {
     expect(await get(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id=1&external_id=2`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -43,7 +43,7 @@ describe('/subscription/status/get', () => {
     expect(await get(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email=example%40braze.com`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -63,7 +63,7 @@ describe('/subscription/status/get', () => {
     expect(await get(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone=%2B11112223333`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/subscription/status/get.ts
+++ b/src/subscription/status/get.ts
@@ -35,7 +35,7 @@ export function get(apiUrl: string, apiKey: string, body: SubscriptionStatusGetO
     }
   })
 
-  return _get(`${apiUrl}/subscription/status/get?${params}`, {}, options) as Promise<{
+  return _get(`${apiUrl}/subscription/status/get?${params}`, undefined, options) as Promise<{
     status: Record<string, 'Subscribed' | 'Unsubscribed' | 'Unknown'>
     message: 'success' | string
   }>


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

The `subscription.status.get` throws an error `TypeError: Request with GET/HEAD method cannot have body` and if I make this change it works.

## What is the current behavior?

Throws error `TypeError: Request with GET/HEAD method cannot have body`

## What is the new behavior?

Does not throw error

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [x] Documentation

<!--
Any other comments? Thank you for contributing!
-->
