### PR TITLE
fix(package): fix "module" field in package.json

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
         run: npm run test:ci
 
       - name: Run module tests
-        run: npm run test:module
+        run: npm run test:esm
 
       - name: Codecov
         uses: codecov/codecov-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -41,8 +41,8 @@ jspm_packages
 .node_repl_history
 
 # Build files
+cjs/
 docs/
-lib/
 
 # Vim swap files
 *.swp

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ jspm_packages
 # Build files
 cjs/
 docs/
+esm/
 
 # Vim swap files
 *.swp

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,4 +3,5 @@
 
 npm run lint:tsc
 npm run test:ci
+npm run test:esm
 npx lint-staged

--- a/module/index.mjs
+++ b/module/index.mjs
@@ -1,1 +1,1 @@
-export { Braze } from '../lib/index.js'
+export { Braze } from '../cjs/index.js'

--- a/module/index.mjs
+++ b/module/index.mjs
@@ -1,1 +1,0 @@
-export { Braze } from '../cjs/index.js'

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "description": "Track users, send messages, export data, and more with Braze API.",
   "author": "Mark <mark@remarkablemark.org>",
   "main": "cjs/index.js",
-  "module": "index.mjs",
+  "module": "esm/index.js",
   "exports": {
-    "types": "./cjs/index.d.ts",
-    "import": "./module/index.mjs",
+    "import": "./esm/index.js",
     "require": "./cjs/index.js"
   },
   "scripts": {
-    "build": "tsc",
-    "clean": "rm -rf coverage cjs docs",
+    "build": "npm run build:cjs && npm run build:esm",
+    "build:cjs": "tsc",
+    "build:esm": "tsc --module nodenext --outDir esm",
+    "clean": "rm -rf cjs coverage docs esm",
     "docs": "typedoc",
     "docs:watch": "npm run docs -- --watch",
     "lint": "eslint --ignore-path .gitignore --ext .js,.mjs,.ts .",
@@ -20,10 +21,10 @@
     "lint:tsc": "tsc --noEmit && tsc --project tsconfig.test.json",
     "postinstall": "husky install",
     "postpublish": "pinst --enable",
-    "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm run test:ci && npm run clean && npm run build",
+    "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm run test:ci && npm run test:esm && npm run clean && npm run build",
     "test": "jest",
     "test:ci": "CI=true jest --ci --colors --coverage",
-    "test:module": "npm run build && node --test module",
+    "test:esm": "npm run build:esm && node --test src",
     "test:watch": "jest --watch"
   },
   "repository": {
@@ -65,7 +66,7 @@
   },
   "files": [
     "cjs/",
-    "module/"
+    "esm/"
   ],
   "engines": {
     "node": ">=14"

--- a/package.json
+++ b/package.json
@@ -3,21 +3,21 @@
   "version": "2.2.1",
   "description": "Track users, send messages, export data, and more with Braze API.",
   "author": "Mark <mark@remarkablemark.org>",
-  "main": "lib/index.js",
+  "main": "cjs/index.js",
   "module": "index.mjs",
   "exports": {
-    "types": "./lib/index.d.ts",
+    "types": "./cjs/index.d.ts",
     "import": "./module/index.mjs",
-    "require": "./lib/index.js"
+    "require": "./cjs/index.js"
   },
   "scripts": {
-    "build": "tsc --project tsconfig.build.json",
-    "clean": "rm -rf coverage docs lib",
+    "build": "tsc",
+    "clean": "rm -rf coverage cjs docs",
     "docs": "typedoc",
     "docs:watch": "npm run docs -- --watch",
-    "lint": "eslint --ignore-path .gitignore --ext .js,.ts .",
+    "lint": "eslint --ignore-path .gitignore --ext .js,.mjs,.ts .",
     "lint:fix": "npm run lint -- --fix",
-    "lint:tsc": "tsc && tsc --project tsconfig.test.json",
+    "lint:tsc": "tsc --noEmit && tsc --project tsconfig.test.json",
     "postinstall": "husky install",
     "postpublish": "pinst --enable",
     "prepublishOnly": "pinst --disable && npm run lint && npm run lint:tsc && npm run test:ci && npm run clean && npm run build",
@@ -64,7 +64,7 @@
     "typescript": "5.1.6"
   },
   "files": [
-    "lib/",
+    "cjs/",
     "module/"
   ],
   "engines": {

--- a/src/index.test.mjs
+++ b/src/index.test.mjs
@@ -2,7 +2,7 @@ import { describe, it } from 'node:test'
 
 import assert from 'assert'
 
-import { Braze } from './index.mjs'
+import { Braze } from '../esm/index.js'
 
 describe('index', () => {
   it('exports "Braze" class', () => {

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "noEmit": false
-  },
-  "exclude": ["node_modules", "**/*.test.ts"]
-}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,9 +8,8 @@
     "sourceMap": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "outDir": "lib",
-    "noEmit": true
+    "outDir": "cjs"
   },
   "include": ["src"],
-  "exclude": ["**/*.test.ts"]
+  "exclude": ["node_modules", "**/*.test.ts"]
 }

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2020", "dom"]
+    "lib": ["es2020", "dom"],
+    "noEmit": true
   },
   "include": ["**/*.test.ts"],
   "exclude": []


### PR DESCRIPTION
## What is the motivation for this pull request?

- fix(package): fix "module" field in package.json
- build: rename `lib` to `cjs`
- build: rename `module` to `esm`

## What is the current behavior?

`package.json` "module" pointing to invalid path

## What is the new behavior?

`package.json` "module" pointing to valid path

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation