### PR TITLE
feat(email-templates): add list, get, create and update

### DIFF
--- a/src/Braze.ts
+++ b/src/Braze.ts
@@ -148,6 +148,16 @@ export class Braze {
       list: (body: templates.content_blocks.ContentBlockListBody) =>
         templates.content_blocks.listContentBlocks(this.apiUrl, this.apiKey, body),
     },
+    email_templates: {
+      get: (body: templates.email_templates.EmailTemplateBody) =>
+        templates.email_templates.getEmailTemplate(this.apiUrl, this.apiKey, body),
+      list: (body: templates.email_templates.EmailTemplateListBody) =>
+        templates.email_templates.getEmailTemplateList(this.apiUrl, this.apiKey, body),
+      create: (body: templates.email_templates.CreateEmailTemplateBody) =>
+        templates.email_templates.createEmailTemplate(this.apiUrl, this.apiKey, body),
+      update: (body: templates.email_templates.UpdateEmailTemplateBody) =>
+        templates.email_templates.updateEmailTemplate(this.apiUrl, this.apiKey, body),
+    },
   }
 
   transactional = {

--- a/src/templates/email-templates/create.ts
+++ b/src/templates/email-templates/create.ts
@@ -1,0 +1,22 @@
+import { post } from '../../common/request'
+import { CreateEmailTemplateBody, PostEmailTemplateResponse } from './types'
+
+/**
+ * Create email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/post_create_email_template/}
+ */
+export function createEmailTemplate(
+  apiUrl: string,
+  apiKey: string,
+  body: CreateEmailTemplateBody,
+): Promise<PostEmailTemplateResponse> {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/templates/email/create`, body, options)
+}

--- a/src/templates/email-templates/email_templates.test.ts
+++ b/src/templates/email-templates/email_templates.test.ts
@@ -1,0 +1,123 @@
+import { Braze } from '../../Braze'
+import { request } from '../../common/request'
+import {
+  EmailTemplateListResponse,
+  EmailTemplateResponse,
+  PostEmailTemplateResponse,
+} from './types'
+
+jest.mock('../../common/request/request')
+const mockedRequest = jest.mocked(request)
+
+const apiUrl = 'https://rest.iad-01.braze.com'
+const apiKey = 'apiKey'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+describe('Email Templates', () => {
+  const braze = new Braze(apiUrl, apiKey)
+  const options = {
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+  }
+
+  describe('Call templates.email_templates.list()', () => {
+    const response: EmailTemplateListResponse = {
+      templates: [],
+      count: 0,
+      message: 'success',
+    }
+
+    it('is called with required params', async () => {
+      mockedRequest.mockResolvedValueOnce(response)
+      expect(await braze.templates.email_templates.list({})).toBe(response)
+      expect(mockedRequest).toBeCalledWith(`${apiUrl}/templates/email/list?`, undefined, options)
+      expect(mockedRequest).toBeCalledTimes(1)
+    })
+  })
+
+  describe('Call templates.email_templates.get()', () => {
+    const response: EmailTemplateResponse = {
+      created_at: '',
+      description: '',
+      email_template_id: '',
+      subject: '',
+      tags: '',
+      template_name: '',
+      updated_at: '',
+      body: '',
+      plaintext_body: '',
+      message: 'success',
+      preheader: '',
+      should_inline_css: true,
+    }
+
+    it('is called with required params', async () => {
+      mockedRequest.mockResolvedValueOnce(response)
+      const emailTemplateId = 'YOUR_EMAIL_TEMPLATE_ID'
+      expect(
+        await braze.templates.email_templates.get({
+          email_template_id: emailTemplateId,
+        }),
+      ).toBe(response)
+      expect(mockedRequest).toBeCalledWith(
+        `${apiUrl}/templates/email/info?email_template_id=${emailTemplateId}`,
+        undefined,
+        options,
+      )
+      expect(mockedRequest).toBeCalledTimes(1)
+    })
+  })
+
+  describe('Call templates.email_templates.create()', () => {
+    const response: PostEmailTemplateResponse = {
+      email_template_id: '',
+      message: 'success',
+    }
+    const requestBody = {
+      body: '',
+      subject: '',
+      template_name: '',
+      plaintext_body: '',
+      preheader: '',
+      should_inline_css: true,
+    }
+
+    it('is called with body', async () => {
+      mockedRequest.mockResolvedValueOnce(response)
+      expect(await braze.templates.email_templates.create(requestBody)).toBe(response)
+      expect(mockedRequest).toBeCalledWith(`${apiUrl}/templates/email/create`, requestBody, {
+        ...options,
+        method: 'POST',
+      })
+      expect(mockedRequest).toBeCalledTimes(1)
+    })
+  })
+
+  describe('Call templates.email_templates.update()', () => {
+    const response: PostEmailTemplateResponse = {
+      email_template_id: '5',
+      message: 'success',
+    }
+    const requestBody = {
+      email_template_id: '5',
+      body: 'New Body',
+      template_name: '',
+      subject: '',
+    }
+
+    it('is called with body', async () => {
+      mockedRequest.mockResolvedValueOnce(response)
+      expect(await braze.templates.email_templates.update(requestBody)).toBe(response)
+      expect(mockedRequest).toBeCalledWith(`${apiUrl}/templates/email/update`, requestBody, {
+        ...options,
+        method: 'POST',
+      })
+      expect(mockedRequest).toBeCalledTimes(1)
+    })
+  })
+})

--- a/src/templates/email-templates/get.ts
+++ b/src/templates/email-templates/get.ts
@@ -1,0 +1,23 @@
+import { get } from '../../common/request'
+import { buildParams } from '../../common/request/params'
+import { EmailTemplateBody, EmailTemplateResponse } from './types'
+
+/**
+ * Request email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/get_see_email_template_information/}
+ */
+export function getEmailTemplate(
+  apiUrl: string,
+  apiKey: string,
+  body: EmailTemplateBody,
+): Promise<EmailTemplateResponse> {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return get(`${apiUrl}/templates/email/info?${buildParams(body)}`, undefined, options)
+}

--- a/src/templates/email-templates/index.ts
+++ b/src/templates/email-templates/index.ts
@@ -1,0 +1,5 @@
+export * from './create'
+export * from './get'
+export * from './list'
+export * from './types'
+export * from './update'

--- a/src/templates/email-templates/list.ts
+++ b/src/templates/email-templates/list.ts
@@ -1,0 +1,23 @@
+import { get } from '../../common/request'
+import { buildParams } from '../../common/request/params'
+import { EmailTemplateListBody, EmailTemplateListResponse } from './types'
+
+/**
+ * Request email template list
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/get_list_email_templates/}
+ */
+export function getEmailTemplateList(
+  apiUrl: string,
+  apiKey: string,
+  body: EmailTemplateListBody,
+): Promise<EmailTemplateListResponse> {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return get(`${apiUrl}/templates/email/list?${buildParams(body)}`, undefined, options)
+}

--- a/src/templates/email-templates/types.ts
+++ b/src/templates/email-templates/types.ts
@@ -1,0 +1,91 @@
+import { ServerResponse } from '../../common/request'
+
+/**
+ * Request body for email template list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/get_list_email_templates/}
+ */
+export interface EmailTemplateListBody {
+  modified_after?: string
+  modified_before?: string
+  limit?: number
+  offset?: number
+}
+
+/**
+ * Response body for email template list.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/get_list_email_templates/}
+ */
+export interface EmailTemplateListResponse extends ServerResponse {
+  count: number
+  templates: {
+    email_template_id: string
+    template_name: string
+    created_at: string
+    updated_at: string
+    tags: string[]
+  }[]
+}
+
+/**
+ * Request body for email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/get_see_email_template_information/}
+ */
+export interface EmailTemplateBody {
+  email_template_id: string
+}
+
+/**
+ * Response body for email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/get_see_email_template_information/}
+ */
+export interface EmailTemplateResponse extends ServerResponse {
+  email_template_id: string
+  template_name: string
+  description: string
+  subject: string
+  preheader?: string
+  body?: string
+  plaintext_body?: string
+  should_inline_css?: boolean
+  tags: string
+  created_at: string
+  updated_at: string
+}
+
+/**
+ * Request body for create/update email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/post_create_email_template/}
+ */
+export interface CreateEmailTemplateBody {
+  template_name: string
+  subject: string
+  body: string
+  plaintext_body?: string
+  preheader?: string
+  tags?: string[]
+  should_inline_css?: boolean
+}
+
+/**
+ * Request body for update email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/post_update_email_template/}
+ */
+export interface UpdateEmailTemplateBody extends CreateEmailTemplateBody {
+  email_template_id: string
+}
+
+/**
+ * Response body for create/update email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/post_create_email_template/}
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/post_update_email_template/}
+ */
+export interface PostEmailTemplateResponse extends ServerResponse {
+  email_template_id: string
+}

--- a/src/templates/email-templates/update.ts
+++ b/src/templates/email-templates/update.ts
@@ -1,0 +1,22 @@
+import { post } from '../../common/request'
+import { PostEmailTemplateResponse, UpdateEmailTemplateBody } from './types'
+
+/**
+ * Update email template.
+ *
+ * {@link https://www.braze.com/docs/api/endpoints/templates/email_templates/post_update_email_template/}
+ */
+export function updateEmailTemplate(
+  apiUrl: string,
+  apiKey: string,
+  body: UpdateEmailTemplateBody,
+): Promise<PostEmailTemplateResponse> {
+  const options = {
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+  }
+
+  return post(`${apiUrl}/templates/email/update`, body, options)
+}

--- a/src/templates/index.ts
+++ b/src/templates/index.ts
@@ -1,1 +1,2 @@
 export * as content_blocks from './content-blocks'
+export * as email_templates from './email-templates'


### PR DESCRIPTION
<!--
Filling out the information below can facilitate the review/merge of the pull request (PR).
-->

## What is the motivation for this pull request?

Adding endpoints for email templates

## What is the current behavior?

Currently we are missing those and we need them to use it within our project

## What is the new behavior?

We can use email templates endpoints as a part of this package

## Checklist:

<!--
Feel free to remove any item that is irrelevant to your changes.
To check an item, place an "x" in the box like so: `- [x] Tests`
-->

- [ ] [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] Tests
- [ ] Documentation

<!--
Any other comments? Thank you for contributing!
-->
