### PR TITLE
fix: ensure body is undefined for GET requests

### DIFF
--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -237,7 +237,7 @@ it('calls subscription.user.status()', async () => {
   expect(await braze.subscription.user.status(body)).toBe(response)
   expect(mockedRequest).toBeCalledWith(
     `${apiUrl}/subscription/user/status?external_id=external_id`,
-    {},
+    undefined,
     { headers: options.headers },
   )
   expect(mockedRequest).toBeCalledTimes(1)

--- a/src/Braze.test.ts
+++ b/src/Braze.test.ts
@@ -190,7 +190,7 @@ it('calls messages.scheduled_broadcasts()', async () => {
   expect(await braze.messages.scheduled_broadcasts({ end_time: '2022-08-21' })).toBe(response)
   expect(mockedRequest).toBeCalledWith(
     `${apiUrl}/messages/scheduled_broadcasts?end_time=2022-08-21`,
-    {},
+    undefined,
     { headers: options.headers },
   )
   expect(mockedRequest).toBeCalledTimes(1)

--- a/src/messages/scheduled_broadcasts.test.ts
+++ b/src/messages/scheduled_broadcasts.test.ts
@@ -8,7 +8,7 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-describe('/messages/scheduled_broadcasts', () => {
+describe('messages.scheduled_broadcasts()', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
   const body = {
@@ -16,12 +16,12 @@ describe('/messages/scheduled_broadcasts', () => {
   }
   const data: ServerResponse = { message: 'success' }
 
-  it('calls request with url and body', async () => {
+  it('calls GET /messages/scheduled_broadcasts with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)
     expect(await scheduled_broadcasts(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/messages/scheduled_broadcasts?end_time=2018-09-01T00%3A00%3A00-04%3A00`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/messages/scheduled_broadcasts.ts
+++ b/src/messages/scheduled_broadcasts.ts
@@ -26,5 +26,5 @@ export function scheduled_broadcasts(
     },
   }
 
-  return get(`${apiUrl}/messages/scheduled_broadcasts?${buildParams(body)}`, {}, options)
+  return get(`${apiUrl}/messages/scheduled_broadcasts?${buildParams(body)}`, undefined, options)
 }

--- a/src/subscription/user/status.test.ts
+++ b/src/subscription/user/status.test.ts
@@ -9,12 +9,12 @@ beforeEach(() => {
   jest.clearAllMocks()
 })
 
-describe('/subscription/user/status', () => {
+describe('subscription.user.status()', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
   const data: ServerResponse = { message: 'success' }
 
-  it('calls request for multiple users with url and body', async () => {
+  it('calls GET /subscription/user/status for multiple users with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)
     const body: SubscriptionUserStatusObject = {
       external_id: ['1', '2'],
@@ -22,7 +22,7 @@ describe('/subscription/user/status', () => {
     expect(await status(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/subscription/user/status?external_id=1&external_id=2`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -33,7 +33,7 @@ describe('/subscription/user/status', () => {
     expect(mockedGet).toBeCalledTimes(1)
   })
 
-  it('calls request for email with url and body', async () => {
+  it('calls GET /subscription/user/status for email with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)
     const body: SubscriptionUserStatusObject = {
       external_id: 'external_id',
@@ -44,7 +44,7 @@ describe('/subscription/user/status', () => {
     expect(await status(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/subscription/user/status?external_id=external_id&email=example%40braze.com&limit=100&offset=1`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',
@@ -55,7 +55,7 @@ describe('/subscription/user/status', () => {
     expect(mockedGet).toBeCalledTimes(1)
   })
 
-  it('calls request for SMS with url and body', async () => {
+  it('calls GET /subscription/user/status for SMS with url and body', async () => {
     mockedGet.mockResolvedValueOnce(data)
     const body: SubscriptionUserStatusObject = {
       external_id: 'external_id',
@@ -66,7 +66,7 @@ describe('/subscription/user/status', () => {
     expect(await status(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
       `${apiUrl}/subscription/user/status?external_id=external_id&phone=%2B11112223333&limit=100&offset=1`,
-      {},
+      undefined,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/subscription/user/status.ts
+++ b/src/subscription/user/status.ts
@@ -39,5 +39,5 @@ export function status(apiUrl: string, apiKey: string, body: SubscriptionUserSta
     params.append('offset', body.offset.toString())
   }
 
-  return get(`${apiUrl}/subscription/user/status?${params}`, {}, options)
+  return get(`${apiUrl}/subscription/user/status?${params}`, undefined, options)
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

- fix(messages): fix GET `/messages/scheduled_broadcasts`
- fix(subscription): fix GET `/subscription/user/status`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation