### PR TITLE
fix(user-subscriptions): pass brackets for array syntax

### DIFF
--- a/src/subscription/status/get.test.ts
+++ b/src/subscription/status/get.test.ts
@@ -14,60 +14,55 @@ describe('/subscription/status/get', () => {
   const apiKey = 'apiKey'
   const data: ServerResponse = { message: 'success' }
 
-  it('calls request for multiple users with url and body', async () => {
-    mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionStatusGetObject = {
-      subscription_group_id: 'subscription_group_id',
-      external_id: ['1', '2'],
-    }
-    expect(await get(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id=1&external_id=2`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+  const testData: { message: string; body: SubscriptionStatusGetObject; expected: string }[] = [
+    {
+      message: 'multiple `external_id`s',
+      body: { subscription_group_id: 'subscription_group_id', external_id: ['1', '2'] },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id%5B%5D=1&external_id%5B%5D=2`,
+    },
+    {
+      message: 'single `external_id`',
+      body: { subscription_group_id: 'subscription_group_id', external_id: '1' },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id=1`,
+    },
+    {
+      message: 'multiple `email`s',
+      body: {
+        subscription_group_id: 'subscription_group_id',
+        email: ['example@braze.com', 'braze@example.com'],
       },
-    )
-    expect(mockedGet).toBeCalledTimes(1)
-  })
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email%5B%5D=example%40braze.com&email%5B%5D=braze%40example.com`,
+    },
+    {
+      message: 'single `email`',
+      body: { subscription_group_id: 'subscription_group_id', email: 'example@braze.com' },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email=example%40braze.com`,
+    },
+    {
+      message: 'multiple `phone`s',
+      body: {
+        subscription_group_id: 'subscription_group_id',
+        phone: ['+11112223333', '+12223334444'],
+      },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone%5B%5D=%2B11112223333&phone%5B%5D=%2B12223334444`,
+    },
+    {
+      message: 'single `phone`',
+      body: { subscription_group_id: 'subscription_group_id', phone: '+11112223333' },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone=%2B11112223333`,
+    },
+  ]
 
-  it('calls request for email with url and body', async () => {
+  it.each(testData)('calls request for ($message)', async ({ body, expected }) => {
     mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionStatusGetObject = {
-      subscription_group_id: 'subscription_group_id',
-      email: 'example@braze.com',
-    }
-    expect(await get(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email=example%40braze.com`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-      },
-    )
-    expect(mockedGet).toBeCalledTimes(1)
-  })
 
-  it('calls request for SMS with url and body', async () => {
-    mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionStatusGetObject = {
-      subscription_group_id: 'subscription_group_id',
-      phone: '+11112223333',
-    }
     expect(await get(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone=%2B11112223333`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+    expect(mockedGet).toBeCalledWith(expected, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
       },
-    )
+    })
     expect(mockedGet).toBeCalledTimes(1)
   })
 })

--- a/src/subscription/status/get.ts
+++ b/src/subscription/status/get.ts
@@ -14,8 +14,18 @@ import type { SubscriptionStatusGetObject } from './types'
  * @returns - Braze response.
  */
 export function get(apiUrl: string, apiKey: string, body: SubscriptionStatusGetObject) {
+  const newBody = Object.entries(body).reduce((agg, [key, value]) => {
+    switch (key) {
+      case 'email':
+      case 'external_id':
+      case 'phone':
+        return { ...agg, [Array.isArray(value) ? key + '[]' : key]: value }
+      default:
+        return { ...agg, [key]: value }
+    }
+  }, {})
   return _get(
-    `${apiUrl}/subscription/status/get?${buildParams(body)}`,
+    `${apiUrl}/subscription/status/get?${buildParams(newBody)}`,
     buildOptions({ apiKey }),
   ) as Promise<{
     status: Record<string, 'Subscribed' | 'Unsubscribed' | 'Unknown'>


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix a bug where passing multiple users to the user subscription lookup endpoint requires `[]` around the keys

https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_groups/?tab=multiple%20users

![image](https://github.com/remarkablemark/braze-api/assets/1482976/9b9e264e-a8e1-41ad-a7e4-9cb4891bc286)

## What is the current behavior?

`/subscription/user/status?external_id=1&external_id=2`

## What is the new behavior?

`/subscription/user/status?external_id[]=1&external_id=2`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
