### PR TITLE
fix(buildParams): use brackets for arrays

### DIFF
--- a/src/common/request/params.test.ts
+++ b/src/common/request/params.test.ts
@@ -47,12 +47,12 @@ describe('buildParams', () => {
 
   describe('array', () => {
     it('handles single', () => {
-      expect(buildParams({ a: [1] })).toBe('a=1')
+      expect(buildParams({ a: [1] })).toBe('a%5B%5D=1')
     })
 
     it('handles multiple', () => {
       expect(buildParams({ a: [1, '2', true, undefined], b: ['foo', 'bar', null] })).toBe(
-        'a=1&a=2&a=true&b=foo&b=bar',
+        'a%5B%5D=1&a%5B%5D=2&a%5B%5D=true&b%5B%5D=foo&b%5B%5D=bar',
       )
     })
   })

--- a/src/common/request/params.ts
+++ b/src/common/request/params.ts
@@ -14,6 +14,9 @@ export function buildParams(parameters?: RequestBody): string {
   }
 
   const searchParams = Object.entries(parameters).reduce((params, [key, value]) => {
+    if (Array.isArray(value)) {
+      return appendParam(params, `${key}[]`, value)
+    }
     return appendParam(params, key, value)
   }, new URLSearchParams())
 

--- a/src/subscription/status/get.test.ts
+++ b/src/subscription/status/get.test.ts
@@ -14,60 +14,55 @@ describe('/subscription/status/get', () => {
   const apiKey = 'apiKey'
   const data: ServerResponse = { message: 'success' }
 
-  it('calls request for multiple users with url and body', async () => {
-    mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionStatusGetObject = {
-      subscription_group_id: 'subscription_group_id',
-      external_id: ['1', '2'],
-    }
-    expect(await get(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id=1&external_id=2`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+  const testData: { message: string; body: SubscriptionStatusGetObject; expected: string }[] = [
+    {
+      message: 'multiple `external_id`s',
+      body: { subscription_group_id: 'subscription_group_id', external_id: ['1', '2'] },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id%5B%5D=1&external_id%5B%5D=2`,
+    },
+    {
+      message: 'single `external_id`',
+      body: { subscription_group_id: 'subscription_group_id', external_id: '1' },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&external_id=1`,
+    },
+    {
+      message: 'multiple `email`s',
+      body: {
+        subscription_group_id: 'subscription_group_id',
+        email: ['example@braze.com', 'braze@example.com'],
       },
-    )
-    expect(mockedGet).toBeCalledTimes(1)
-  })
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email%5B%5D=example%40braze.com&email%5B%5D=braze%40example.com`,
+    },
+    {
+      message: 'single `email`',
+      body: { subscription_group_id: 'subscription_group_id', email: 'example@braze.com' },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email=example%40braze.com`,
+    },
+    {
+      message: 'multiple `phone`s',
+      body: {
+        subscription_group_id: 'subscription_group_id',
+        phone: ['+11112223333', '+12223334444'],
+      },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone%5B%5D=%2B11112223333&phone%5B%5D=%2B12223334444`,
+    },
+    {
+      message: 'single `phone`',
+      body: { subscription_group_id: 'subscription_group_id', phone: '+11112223333' },
+      expected: `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone=%2B11112223333`,
+    },
+  ]
 
-  it('calls request for email with url and body', async () => {
+  it.each(testData)('calls request for ($message)', async ({ body, expected }) => {
     mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionStatusGetObject = {
-      subscription_group_id: 'subscription_group_id',
-      email: 'example@braze.com',
-    }
-    expect(await get(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&email=example%40braze.com`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
-      },
-    )
-    expect(mockedGet).toBeCalledTimes(1)
-  })
 
-  it('calls request for SMS with url and body', async () => {
-    mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionStatusGetObject = {
-      subscription_group_id: 'subscription_group_id',
-      phone: '+11112223333',
-    }
     expect(await get(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/status/get?subscription_group_id=subscription_group_id&phone=%2B11112223333`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+    expect(mockedGet).toBeCalledWith(expected, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
       },
-    )
+    })
     expect(mockedGet).toBeCalledTimes(1)
   })
 })

--- a/src/subscription/user/status.test.ts
+++ b/src/subscription/user/status.test.ts
@@ -1,6 +1,6 @@
-import { get, ServerResponse } from '../../common/request'
-import { status } from '.'
-import type { SubscriptionUserStatusObject } from './types'
+import { get } from '../../common/request'
+import { status } from './status'
+import type { SubscriptionUserStatusObject, SubscriptionUserStatusResponse } from './types'
 
 jest.mock('../../common/request/get')
 const mockedGet = jest.mocked(get)
@@ -12,65 +12,72 @@ beforeEach(() => {
 describe('subscription.user.status()', () => {
   const apiUrl = 'https://rest.iad-01.braze.com'
   const apiKey = 'apiKey'
-  const data: ServerResponse = { message: 'success' }
-
-  it('calls GET /subscription/user/status for multiple users with url and body', async () => {
-    mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionUserStatusObject = {
-      external_id: ['1', '2'],
-    }
-    expect(await status(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/user/status?external_id%5B%5D=1&external_id%5B%5D=2`,
+  const data: SubscriptionUserStatusResponse = {
+    message: 'success',
+    users: [
       {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+        external_id: '1',
+        email: null,
+        phone: null,
+        subscription_groups: [
+          {
+            id: '11111111-2222-3333-4444-555555555555',
+            name: 'subscription group',
+            channel: 'email',
+            status: 'Subscribed',
+          },
+        ],
       },
-    )
-    expect(mockedGet).toBeCalledTimes(1)
-  })
+    ],
+    total_count: 1,
+  }
 
-  it('calls GET /subscription/user/status for email with url and body', async () => {
-    mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionUserStatusObject = {
-      external_id: 'external_id',
-      email: 'example@braze.com',
-      limit: 100,
-      offset: 1,
-    }
-    expect(await status(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/user/status?external_id=external_id&email=example%40braze.com&limit=100&offset=1`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+  const testData: { message: string; body: SubscriptionUserStatusObject; expected: string }[] = [
+    {
+      message: 'multiple `external_id`s',
+      body: { external_id: ['1', '2'] },
+      expected: `${apiUrl}/subscription/user/status?external_id%5B%5D=1&external_id%5B%5D=2`,
+    },
+    {
+      message: 'single `external_id`',
+      body: { external_id: '1' },
+      expected: `${apiUrl}/subscription/user/status?external_id=1`,
+    },
+    {
+      message: 'multiple `email`s',
+      body: {
+        email: ['example@braze.com', 'braze@example.com'],
       },
-    )
-    expect(mockedGet).toBeCalledTimes(1)
-  })
+      expected: `${apiUrl}/subscription/user/status?email%5B%5D=example%40braze.com&email%5B%5D=braze%40example.com`,
+    },
+    {
+      message: 'single `email`',
+      body: { email: 'example@braze.com' },
+      expected: `${apiUrl}/subscription/user/status?email=example%40braze.com`,
+    },
+    {
+      message: 'multiple `phone`s',
+      body: {
+        phone: ['+11112223333', '+12223334444'],
+      },
+      expected: `${apiUrl}/subscription/user/status?phone%5B%5D=%2B11112223333&phone%5B%5D=%2B12223334444`,
+    },
+    {
+      message: 'single `phone`',
+      body: { phone: '+11112223333' },
+      expected: `${apiUrl}/subscription/user/status?phone=%2B11112223333`,
+    },
+  ]
 
-  it('calls GET /subscription/user/status for SMS with url and body', async () => {
+  it.each(testData)('calls request for ($message)', async ({ body, expected }) => {
     mockedGet.mockResolvedValueOnce(data)
-    const body: SubscriptionUserStatusObject = {
-      external_id: 'external_id',
-      phone: '+11112223333',
-      limit: 100,
-      offset: 1,
-    }
     expect(await status(apiUrl, apiKey, body)).toBe(data)
-    expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/user/status?external_id=external_id&phone=%2B11112223333&limit=100&offset=1`,
-      {
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${apiKey}`,
-        },
+    expect(mockedGet).toBeCalledWith(expected, {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
       },
-    )
+    })
     expect(mockedGet).toBeCalledTimes(1)
   })
 })

--- a/src/subscription/user/status.test.ts
+++ b/src/subscription/user/status.test.ts
@@ -21,7 +21,7 @@ describe('subscription.user.status()', () => {
     }
     expect(await status(apiUrl, apiKey, body)).toBe(data)
     expect(mockedGet).toBeCalledWith(
-      `${apiUrl}/subscription/user/status?external_id=1&external_id=2`,
+      `${apiUrl}/subscription/user/status?external_id%5B%5D=1&external_id%5B%5D=2`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/subscription/user/status.ts
+++ b/src/subscription/user/status.ts
@@ -1,5 +1,6 @@
 import { buildOptions, buildParams, get } from '../../common/request'
 import type { SubscriptionUserStatusObject } from './types'
+import { SubscriptionUserStatusResponse } from './types'
 
 /**
  * Get users’ subscription groups.
@@ -14,5 +15,8 @@ import type { SubscriptionUserStatusObject } from './types'
  * @returns - Braze response.
  */
 export function status(apiUrl: string, apiKey: string, body: SubscriptionUserStatusObject) {
-  return get(`${apiUrl}/subscription/user/status?${buildParams(body)}`, buildOptions({ apiKey }))
+  return get<SubscriptionUserStatusResponse>(
+    `${apiUrl}/subscription/user/status?${buildParams(body)}`,
+    buildOptions({ apiKey }),
+  )
 }

--- a/src/subscription/user/types.ts
+++ b/src/subscription/user/types.ts
@@ -4,9 +4,26 @@
  * {@link https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_groups/#request-parameters}
  */
 export interface SubscriptionUserStatusObject {
-  external_id: string | string[]
+  external_id?: string | string[]
   email?: string | string[]
   phone?: string | string[]
   limit?: number
   offset?: number
+}
+
+export interface SubscriptionUserStatusResponse {
+  users: Array<{
+    email: string | null
+    phone: string | null
+    external_id: string | null
+    subscription_groups: Array<{
+      id: string
+      name: string
+      channel: string
+      status: 'Subscribed' | 'Unsubscribed'
+    }>
+  }>
+  total_count: number
+  message: string
+  errors?: string[]
 }


### PR DESCRIPTION
## What is the motivation for this pull request?

Fix a bug where passing multiple users to the user subscription lookup endpoint requires `[]` around the keys

https://www.braze.com/docs/api/endpoints/subscription_groups/get_list_user_subscription_groups/?tab=multiple%20users

![image](https://github.com/remarkablemark/braze-api/assets/1482976/9b9e264e-a8e1-41ad-a7e4-9cb4891bc286)

This will replace #328 if we like this style better. I do, but it's only if Braze is consistent with this.

## What is the current behavior?

`/subscription/user/status?external_id=1&external_id=2`

## What is the new behavior?

`/subscription/user/status?external_id[]=1&external_id=2`

## Checklist:

- [x] [Conventional Commits](https://www.conventionalcommits.org/)
- [x] Tests
- [ ] Documentation
